### PR TITLE
fix: content 안의 메세지를 heredoc 형식으로 재변경

### DIFF
--- a/.github/workflows/discord-pr-merged-notify.yml
+++ b/.github/workflows/discord-pr-merged-notify.yml
@@ -13,9 +13,10 @@ jobs:
     steps:
       - name: Send test message to Discord
         run: |
-          curl -H "Content-Type: application/json" \
-               -X POST \
-               -d '{
-                 "content": "✅ PR Merged to **develop**!\n\n**Title:** ${{ github.event.pull_request.title }}\n**Author:** ${{ github.event.pull_request.user.login }}\n\n📝 **Description:**\n${{ github.event.pull_request.body }}\n\n🔗 <${{ github.event.pull_request.html_url }}"
-               }' \
-               "${{ secrets.DISCORD_WEBHOOK_URL }}"
+            curl -H "Content-Type: application/json" \
+                -X POST \
+                -d @- "${{ secrets.DISCORD_WEBHOOK_URL }}" <<EOF
+            {
+                "content": "✅ PR Merged to **develop**!\n\n**Title:** ${{ github.event.pull_request.title }}\n**Author:** ${{ github.event.pull_request.user.login }}\n\n📝 **Description:**\n${{ github.event.pull_request.body }}\n\n🔗 <${{ github.event.pull_request.html_url }}"
+            }
+            EOF


### PR DESCRIPTION
## 🔗 관련 이슈
- #13 

## ✏️ 변경 사항
- curl 명령어 안의 디스코드 알림 메세지를 heredoc 형식으로 다시 변경

## 📋 상세 설명
- JSON 포맷이 깨지는 오류로 인하여, 디스코드 알림 메세지를 heredoc 형식으로 다시 변경
- PR 관련 기능을 테스트하기 위해 PR Merge 중입니다.

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- x

## 📎 참고 자료 (선택)
- x