### PR TITLE
fix: 디스코드 메세지에서 PR 본문에 대한 형식 변경

### DIFF
--- a/.github/workflows/discord-pr-merged-notify.yml
+++ b/.github/workflows/discord-pr-merged-notify.yml
@@ -11,12 +11,19 @@ jobs:
     if: github.event.pull_request.merged == true  # 병합된 경우만 실행
     runs-on: ubuntu-latest
     steps:
-      - name: Send test message to Discord
+      - name: Send PR info to Discord
         run: |
             curl -H "Content-Type: application/json" \
                 -X POST \
                 -d @- "${{ secrets.DISCORD_WEBHOOK_URL }}" <<EOF
             {
-                "content": "✅ PR Merged to **develop**!\n\n**Title:** ${{ github.event.pull_request.title }}\n**Author:** ${{ github.event.pull_request.user.login }}\n\n📝 **Description:**\n${{ github.event.pull_request.body }}\n\n🔗 <${{ github.event.pull_request.html_url }}"
+            "embeds": [
+                {
+                "title": "✅ PR Merged to develop!",
+                "description": "**Title:** ${{ github.event.pull_request.title }}\\n**Author:** ${{ github.event.pull_request.user.login }}\\n\\n📝 **Description:**\\n${{ github.event.pull_request.body }}",
+                "url": "${{ github.event.pull_request.html_url }}",
+                "color": 3066993
+                }
+            ]
             }
             EOF


### PR DESCRIPTION
## 🔗 관련 이슈
- #14 

## ✏️ 변경 사항
- 디스코드 알림 메시지의 형식 변경

## 📋 상세 설명
- 디스코드 알림으로 요청오는데 성공하였으나, 텍스트의 마크다운 형식이 깨져서 옴
- Discord 웹훅의 `embeds`를 이용하여 마크다운 형식 유지 시도

## ✅ 체크리스트
- x

## 👀 리뷰 요청 사항
- x

## 📎 참고 자료 (선택)
- PR 메세지 원본
![image](https://github.com/user-attachments/assets/f33e25fd-b996-46c8-83fb-12ab7fdf49fc)
- 디스코드에 온 알림
![image](https://github.com/user-attachments/assets/f270cf06-d685-4f10-b837-806fec8d31c5)
