### PR TITLE
fix: PR 메세지의 description을 code block으로 처리

### DIFF
--- a/.github/workflows/discord-pr-merged-notify.yml
+++ b/.github/workflows/discord-pr-merged-notify.yml
@@ -20,7 +20,7 @@ jobs:
             "embeds": [
                 {
                 "title": "✅ PR Merged to develop!",
-                "description": "**Title:** ${{ github.event.pull_request.title }}\\n**Author:** ${{ github.event.pull_request.user.login }}\\n\\n📝 **Description:**\\n${{ github.event.pull_request.body }}",
+                "description": "```markdown\n**Title:** ${{ github.event.pull_request.title }}\n**Author:** ${{ github.event.pull_request.user.login }}\n\n📝 **Description:**\n${{ github.event.pull_request.body }}\n```",
                 "url": "${{ github.event.pull_request.html_url }}",
                 "color": 3066993
                 }


### PR DESCRIPTION
## 🔗 관련 이슈
- #15 

## ✏️ 변경 사항
- PR 메세지의 description을 code block으로 처리

## 📋 상세 설명
- curl 명령을 보내는 스크립트에서, 마크다운 문법으로 작성된 PR 메세지의 description을 제대로 처리하지 못함
- 그래서 description을 통째로 code block으로 감쌈
- PR 관련 기능을 테스트하기 위해 PR Merge 중입니다.

## ✅ 체크리스트
- x

## 👀 리뷰 요청 사항
- x

## 📎 참고 자료 (선택)
- x