### PR TITLE
fix: 디스코드 봇 url을 Github Secrets에서 가져오게 변경

### DIFF
--- a/backend/workflows/cd-backend.yml
+++ b/backend/workflows/cd-backend.yml
@@ -131,7 +131,7 @@ jobs:
           curl -H "Content-Type: application/json" \
             -X POST \
             -d "{\"content\": \"❌ [BE 배포 실패] **${{ env.ENV }}** Backend 서버 (브랜치: \`${{ env.BRANCH }}\`)\\n🔖 Commit: ${{ env.COMMIT_HASH }}\\n⚠️ [워크플로우 로그 보기]($WORKFLOW_URL)\"}" \
-            ${{ env.DISCORD_WEBHOOK_CICD_URL }}
+            ${{ secrets.DISCORD_WEBHOOK_CICD_URL }}
 
       - name: Send success notification
         if: success()
@@ -139,7 +139,7 @@ jobs:
           curl -H "Content-Type: application/json" \
             -X POST \
             -d "{\"content\": \"🚀 [BE 배포 완료] **${{ env.ENV }}** Backend 서버 (브랜치: \`${{ env.BRANCH }}\`)\\n🔖 Commit: ${{ env.COMMIT_HASH }}\"}" \
-            ${{ env.DISCORD_WEBHOOK_CICD_URL }}
+            ${{ secrets.DISCORD_WEBHOOK_CICD_URL }}
 
   rollback-production:
     if: failure() && github.ref == 'refs/heads/main'


### PR DESCRIPTION
## 🔗 관련 이슈
- ㅌ

## ✏️ 변경 사항
- 디스코드 봇 url을 Github Secrets에서 가져오게 변경

## 📋 상세 설명
- 디스코드 봇 url을 Github Secrets에서 가져오게 변경

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.