### PR TITLE
fix: nat-게이트웨이 퍼블릭 서브넷으로 변경

### DIFF
--- a/terraform/environments/shared/main.tf
+++ b/terraform/environments/shared/main.tf
@@ -35,7 +35,7 @@ module "subnet" {
 module "nat_gateway" {
   source    = "../../modules/nat_gateway"
   env       = var.env
-  subnet_id = module.subnet.nat_subnet_ids[0]
+  subnet_id = module.subnet.public_subnet_ids[0]
 }
 
 module "public_route_table" {


### PR DESCRIPTION
## 🔗 관련 이슈
[Sprint #4 - CL] - terraform-ec2 [#221](https://github.com/100-hours-a-week/2-hertz-wiki/issues/221)

## ✏️ 변경 사항
- NatGateway가 private subnet에 위치하여 인터넷이 안되는 이슈가 있었다.
- public subnet으로 변경

## 📋 상세 설명
 - NatGateWay는 public에 위치하여야 eip를 통한 인터넷 통신이 가능하다.

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.