### PR TITLE
feat: user data

### DIFF
--- a/terraform/environments/shared/main.tf
+++ b/terraform/environments/shared/main.tf
@@ -119,10 +119,20 @@ module "ec2" {
   ami_id         = "ami-05377cf8cfef186c2"             # amazon linux 2
   instance_type  = "t3.medium"                          # 프리 티어 사용
   key_name       = var.key_name
-  
-  user_data       = templatefile("${path.module}/scripts/ec2-init.sh.tpl", {
-    admin_password = var.openvpn_admin_password
-  })
+ 
+ user_data = templatefile("${path.module}/scripts/dynamic-combine-init.sh.tpl", {
+  base_script = templatefile("${path.module}/scripts/base-init.sh.tpl", {
+    # 기본 스크립트 변수들...
+
+  }),
+  scripts = {
+     /* 추가 스크립트들...
+    "nextjs" = templatefile("${path.module}/scripts/nextjs-init.sh.tpl", {
+      ecr_repo_url = module.ecr_nextjs.repository_url
+      ecr_repo_name = module.ecr_nextjs.repository_name
+      */
+  }
+})
 
   # 필요하다면 인그레스 규칙을 추가적으로 지정
   /*ingress_rules = [
@@ -144,3 +154,4 @@ module "ec2" {
   ]*/
   
 }
+

--- a/terraform/environments/shared/scripts/dynamic-combine-init.sh.tpl
+++ b/terraform/environments/shared/scripts/dynamic-combine-init.sh.tpl
@@ -1,0 +1,18 @@
+#!/bin/bash
+exec > >(tee /var/log/user-data-combined.log) 2>&1
+echo "### [START] Dynamic Combined UserData Script - $(date)"
+
+# 기본 초기화 스크립트 (항상 실행)
+${base_script}
+
+# 동적으로 선택된 스크립트들 실행
+%{ for script_name, script_content in scripts }
+# --- Begin Script: ${script_name} ---
+echo "### [EXECUTING] Script: ${script_name} - $(date)"
+${script_content}
+echo "### [COMPLETED] Script: ${script_name} - $(date)"
+# --- End Script: ${script_name} ---
+
+%{ endfor }
+
+echo "### [COMPLETED] Dynamic Combined UserData Script - $(date)"

--- a/terraform/environments/shared/scripts/ec2-init.sh.tpl
+++ b/terraform/environments/shared/scripts/ec2-init.sh.tpl
@@ -5,7 +5,7 @@ echo "### [START] UserData Script - $(date)"
 # 1. 시스템 패키지 업데이트
 yum update -y
 
-# 2. deploy 유저 생성 (비밀번호 없이, 홈 디렉토리 포함)
+# 2. deploy 사용자 생성 (비밀번호 없이, 홈 디렉토리 포함)
 if ! id deploy &>/dev/null; then
   useradd -m deploy
 fi
@@ -13,29 +13,29 @@ fi
 mkdir -p /home/deploy/.ssh
 chmod 700 /home/deploy/.ssh
 
-# 기본 사용자의 authorized_keys 파일을 복사 (Amazon Linux 2는 ec2-user)
+# 기본 사용자의 authorized_keys 파일 복사
 cp /home/ec2-user/.ssh/authorized_keys /home/deploy/.ssh/
 chmod 600 /home/deploy/.ssh/authorized_keys
 chown -R deploy:deploy /home/deploy/.ssh
 
-# 3. deploy 유저를 docker 그룹에만 추가 (sudo 권한 부여하지 않음)
-usermod -aG docker deploy || true
-
-# 4. Docker 설치 (Amazon Linux 2는 amazon-linux-extras 사용)
+# 3. Docker 설치 (Amazon Linux 2023는 dnf 사용)
 if ! command -v docker >/dev/null 2>&1; then
-  amazon-linux-extras install docker -y
-  yum install -y docker
+  dnf install -y docker
 fi
 
 systemctl enable docker
 systemctl start docker
+
+# 4. Docker 설치 후 deploy 사용자를 docker 그룹에 추가
+getent group docker || groupadd docker
+usermod -aG docker deploy
 
 # 5. CodeDeploy Agent 설치
 if ! systemctl is-active --quiet codedeploy-agent; then
   yum install -y ruby wget
   REGION=$(curl -s http://169.254.169.254/latest/meta-data/placement/region)
   cd /home/deploy || cd /tmp
-  wget https://aws-codedeploy-$${REGION}.s3.$${REGION}.amazonaws.com/latest/install
+  wget "https://aws-codedeploy-${REGION}.s3.${REGION}.amazonaws.com/latest/install"
   chmod +x ./install
   ./install auto
   systemctl enable codedeploy-agent
@@ -45,7 +45,7 @@ fi
 # 6. (옵션) Docker Compose v2 설치
 if ! command -v docker-compose >/dev/null 2>&1; then
   DOCKER_COMPOSE_VERSION="2.29.2"
-  curl -L "https://github.com/docker/compose/releases/download/v$${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+  curl -L "https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
   chmod +x /usr/local/bin/docker-compose
   ln -s /usr/local/bin/docker-compose /usr/bin/docker-compose || true
 fi


### PR DESCRIPTION
## 🔗 관련 이슈
[Sprint #4 - CL] - terraform-ec2
[#221](https://github.com/100-hours-a-week/2-hertz-wiki/issues/221)

## ✏️ 변경 사항
- user_data를 동적으로 넣을 수 있도록 수정
- ec2-init 오류 수정

## 📋 상세 설명
```
user_data = templatefile("${path.module}/scripts/dynamic-combine-init.sh.tpl", {
  base_script = templatefile("${path.module}/scripts/base-init.sh.tpl", {
    # 기본 스크립트 변수들...

  }),
  scripts = {
     /* 추가 스크립트들...
    "nextjs" = templatefile("${path.module}/scripts/nextjs-init.sh.tpl", {
      ecr_repo_url = module.ecr_nextjs.repository_url
      ecr_repo_name = module.ecr_nextjs.repository_name
      */
  }
})
```
다음과 같이 동적으로 user_data 넣을 수 있다.

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.