### PR TITLE
fix: 네트워크 타겟 태그 수정

### DIFF
--- a/terraform/gcp/environments/shared/main.tf
+++ b/terraform/gcp/environments/shared/main.tf
@@ -173,7 +173,7 @@ module "backend" {
     zone                  = "asia-east1-b"
     image                 = "ubuntu-os-cloud/ubuntu-2204-lts"
     disk_size_gb          = 10
-    tags                  = ["ssh-from-vpn"]
+    tags                  = ["allow-vpn-ssh"]
     
     subnetwork            = module.network.subnets["${var.vpc_name}-nat-b"].self_link
     


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- 네트워크 타겟 태그 이름이 맞지 않았던 것을 수정

## 📋 상세 설명

```
module "backend" {
    source                = "../../modules/compute"
    name                  = "backend"
    machine_type          = "e2-medium"
    zone                  = "asia-east1-b"
    image                 = "ubuntu-os-cloud/ubuntu-2204-lts"
    disk_size_gb          = 10
    tags                  = ["allow-vpn-ssh"]
```
```
{
  name          = "ssh-from-vpn"
  env           = var.env
  direction     = "INGRESS"
  priority      = 1003
  protocol      = "tcp"
  ports         = ["22"]
  source_ranges = var.vpn_client_cidr_blocks 
  target_tags   = ["allow-vpn-ssh"]
  description   = "Allow SSH from VPN clients"
}
```
## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.