### PR TITLE
fix: vpn 라우팅 주소 추가

### DIFF
--- a/terraform/gcp/environments/shared/main.tf
+++ b/terraform/gcp/environments/shared/main.tf
@@ -140,7 +140,12 @@ module "firewall" {
   vpc_name       = module.network.vpc_name
   firewall_rules = local.firewall_rules
 }
-
+locals {
+  vpn_private_networks = concat(
+    [for s in local.private_subnets : s.cidr],
+    [for s in local.nat_subnets : s.cidr]
+  )
+}
 
 module "bastion_openvpn" {
   source                = "../../modules/compute"
@@ -153,9 +158,10 @@ module "bastion_openvpn" {
 
   subnetwork            = module.network.subnets["${var.vpc_name}-public-b"].self_link
  
-  extra_startup_script = templatefile("${path.module}/scripts/install-openvpn.sh.tpl", {
-    openvpn_admin_password = var.openvpn_admin_password
-  })
+ extra_startup_script = templatefile("${path.module}/scripts/install-openvpn.sh.tpl", {
+  openvpn_admin_password = var.openvpn_admin_password,
+  vpn_private_networks   = join(",", local.vpn_private_networks)
+})
 
   # ✅ deploy 계정의 SSH 키는 base-init.sh.tpl에서 사용됨
   deploy_ssh_public_key = var.ssh_private_key

--- a/terraform/gcp/environments/shared/main.tf
+++ b/terraform/gcp/environments/shared/main.tf
@@ -158,10 +158,10 @@ module "bastion_openvpn" {
 
   subnetwork            = module.network.subnets["${var.vpc_name}-public-b"].self_link
  
- extra_startup_script = templatefile("${path.module}/scripts/install-openvpn.sh.tpl", {
-  openvpn_admin_password = var.openvpn_admin_password,
-  vpn_private_networks   = join(",", local.vpn_private_networks)
-})
+  extra_startup_script = templatefile("${path.module}/scripts/install-openvpn.sh.tpl", {
+    openvpn_admin_password = var.openvpn_admin_password,
+    vpn_private_networks   = join(",", local.vpn_private_networks)
+  })
 
   # ✅ deploy 계정의 SSH 키는 base-init.sh.tpl에서 사용됨
   deploy_ssh_public_key = var.ssh_private_key

--- a/terraform/gcp/environments/shared/main.tf
+++ b/terraform/gcp/environments/shared/main.tf
@@ -140,6 +140,9 @@ module "firewall" {
   vpc_name       = module.network.vpc_name
   firewall_rules = local.firewall_rules
 }
+
+
+
 locals {
   vpn_private_networks = concat(
     [for s in local.private_subnets : s.cidr],
@@ -159,10 +162,9 @@ module "bastion_openvpn" {
   subnetwork            = module.network.subnets["${var.vpc_name}-public-b"].self_link
  
   extra_startup_script = templatefile("${path.module}/scripts/install-openvpn.sh.tpl", {
-    openvpn_admin_password = var.openvpn_admin_password,
-    vpn_private_networks   = join(",", local.vpn_private_networks)
-  })
-
+  openvpn_admin_password = var.openvpn_admin_password,
+  vpn_private_networks   = join(",", local.vpn_private_networks)
+})
   # ✅ deploy 계정의 SSH 키는 base-init.sh.tpl에서 사용됨
   deploy_ssh_public_key = var.ssh_private_key
 

--- a/terraform/gcp/environments/shared/scripts/install-openvpn.sh.tpl
+++ b/terraform/gcp/environments/shared/scripts/install-openvpn.sh.tpl
@@ -231,11 +231,9 @@ sudo /root/fix-openvpn-ip.sh
 VPN_PRIVATE_NETWORKS="${vpn_private_networks:-""}"
 IFS=',' read -ra SUBNETS <<< "$VPN_PRIVATE_NETWORKS"
 
-echo "[INFO] OpenVPN 라우팅에 아래 CIDR들을 추가합니다:"
 for i in "${!SUBNETS[@]}"; do
     CIDR="${SUBNETS[$i]}"
     if [[ -n "$CIDR" ]]; then
-        echo "  - $CIDR"
         sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.server.routing.private_network.${i}" --value "$CIDR" ConfigPut
     fi
 done

--- a/terraform/gcp/environments/shared/scripts/install-openvpn.sh.tpl
+++ b/terraform/gcp/environments/shared/scripts/install-openvpn.sh.tpl
@@ -228,15 +228,18 @@ sudo chmod +x /root/fix-openvpn-ip.sh
 sudo /root/fix-openvpn-ip.sh
 
 # 내부망(서브넷) 자동 라우팅 등록
-VPN_PRIVATE_NETWORKS="${vpn_private_networks:-""}"
+VPN_PRIVATE_NETWORKS="${vpn_private_networks:-""}" 
 IFS=',' read -ra SUBNETS <<< "$VPN_PRIVATE_NETWORKS"
 
+echo "[INFO] OpenVPN 라우팅에 아래 CIDR들을 추가합니다:"
 for i in "${!SUBNETS[@]}"; do
     CIDR="${SUBNETS[$i]}"
     if [[ -n "$CIDR" ]]; then
+        echo "  - $CIDR"
         sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.server.routing.private_network.${i}" --value "$CIDR" ConfigPut
     fi
 done
+
 
 # 6. 서비스 재시작
 sudo service openvpnas restart

--- a/terraform/gcp/environments/shared/scripts/install-openvpn.sh.tpl
+++ b/terraform/gcp/environments/shared/scripts/install-openvpn.sh.tpl
@@ -205,7 +205,7 @@ sudo /usr/local/openvpn_as/scripts/sacli --user openvpn --new_pass "$CUSTOM_PASS
 sudo tee /root/fix-openvpn-ip.sh > /dev/null << 'EOF'
 #!/bin/bash
 EXTERNAL_IP=$(curl -s ifconfig.me)
-echo "🔧 외부 IP: $EXTERNAL_IP 로 설정 중..."
+echo "[INFO] 외부 IP: $EXTERNAL_IP 로 설정 중..."
 
 sudo /usr/local/openvpn_as/scripts/sacli --key "host.name" --value "$EXTERNAL_IP" ConfigPut
 sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.daemon.0.listen.ip" --value "all" ConfigPut
@@ -221,17 +221,15 @@ sudo ufw allow 943/tcp 2>/dev/null
 
 sudo /usr/local/openvpn_as/scripts/sacli start
 
-echo "✅ 완료! Admin UI: https://$EXTERNAL_IP:943/admin"
+echo "[INFO] 완료! Admin UI: https://$EXTERNAL_IP:943/admin"
 EOF
 
 sudo chmod +x /root/fix-openvpn-ip.sh
 sudo /root/fix-openvpn-ip.sh
 
-# 내부망(서브넷) 자동 라우팅 등록
 VPN_PRIVATE_NETWORKS="${vpn_private_networks:-""}" 
 IFS=',' read -ra SUBNETS <<< "$VPN_PRIVATE_NETWORKS"
 
-echo "[INFO] OpenVPN 라우팅에 아래 CIDR들을 추가합니다:"
 for i in "${!SUBNETS[@]}"; do
     CIDR="${SUBNETS[$i]}"
     if [[ -n "$CIDR" ]]; then

--- a/terraform/gcp/environments/shared/scripts/install-openvpn.sh.tpl
+++ b/terraform/gcp/environments/shared/scripts/install-openvpn.sh.tpl
@@ -1,49 +1,40 @@
 #!/bin/bash
 set -e
 
-# 로그 설정
 exec > >(tee /var/log/user-data.log) 2>&1
 echo "======================================================"
-echo "OpenVPN Access Server 설치 시작: $(date)"
+echo "OpenVPN Access Server install started: $(date)"
 echo "======================================================"
 
 CUSTOM_PASSWORD="${openvpn_admin_password}"
 if [ -z "$CUSTOM_PASSWORD" ]; then
-  echo "[ERROR] 관리자 비밀번호가 설정되지 않았습니다. 종료합니다."
+  echo "[ERROR] Admin password not set. Exiting."
   exit 1
 fi
-echo "[INFO] 설정할 관리자 비밀번호: $CUSTOM_PASSWORD"
+echo "[INFO] Admin password configured"
 
-
-# 서버 IP 추출
+echo "[INFO] Getting server IP from GCP metadata..."
 SERVER_IP=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/access-configs/0/external-ip)
-echo "[INFO] Public IP: $SERVER_IP"
-
+INTERNAL_IP=$(curl -s -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip)
+echo "[INFO] External IP: $SERVER_IP"
+echo "[INFO] Internal IP: $INTERNAL_IP"
 
 sudo apt-get update -y
 sudo apt-get install -y curl wget net-tools expect
 
-# OpenVPN Access Server 다운로드 및 설치
+echo "[INFO] Adding OpenVPN repository..."
 sudo wget https://as-repository.openvpn.net/as-repo-public.asc -qO /etc/apt/trusted.gpg.d/as-repository.asc
 echo "deb [arch=amd64 signed-by=/etc/apt/trusted.gpg.d/as-repository.asc] http://as-repository.openvpn.net/as/debian jammy main" | sudo tee /etc/apt/sources.list.d/openvpn-as-repo.list
 sudo apt update && sudo apt -y install openvpn-as
 
-
-# OpenVPN 초기화 자동화 expect 스크립트 생성
-#!/bin/bash
-
-# 수정된 OpenVPN Access Server 자동 초기화 스크립트
-sudo tee /root/auto-ovpn-init.expect > /dev/null << 'EOF'
+echo "[INFO] Creating OpenVPN initialization script..."
+sudo tee /root/auto-ovpn-init.expect > /dev/null << 'EXPECTSCRIPT'
 #!/usr/bin/expect -f
 
-set activation_key ""
 
-# 디버그 모드 활성화 (문제 해결용)
-# exp_internal 1
 
 spawn sudo /usr/local/openvpn_as/bin/ovpn-init
 
-# 기존 설정 삭제 여부 (필요시)
 expect {
     "Please enter 'DELETE' to delete existing configuration" {
         send "DELETE\r"
@@ -54,217 +45,159 @@ expect {
     }
 }
 
-# Primary Access Server 노드 설정
-expect {
-    -re "Press ENTER for default.*yes.*:" {
-        send "\r"
-    }
+expect -re "Press ENTER for default.*yes.*:" {
+    send "\r"
 }
 
-# 네트워크 인터페이스 선택
-expect {
-    -re "Please enter the option number.*>" {
-        send "1\r"
-    }
+expect -re "Please enter the option number.*>" {
+    send "1\r"
 }
 
-# OpenVPN CA 암호화 알고리즘
-expect {
-    -re "Press ENTER for default.*secp384r1.*:" {
-        send "\r"
-    }
+expect -re "Press ENTER for default.*secp384r1.*:" {
+    send "\r"
 }
 
-# 웹 인증서 암호화 알고리즘
-expect {
-    -re "Press ENTER for default.*secp384r1.*:" {
-        send "\r"
-    }
+expect -re "Press ENTER for default.*secp384r1.*:" {
+    send "\r"
 }
 
-# Admin Web UI 포트
-expect {
-    -re "Press ENTER for default.*943.*:" {
-        send "\r"
-    }
+expect -re "Press ENTER for default.*943.*:" {
+    send "\r"
 }
 
-# OpenVPN Daemon TCP 포트
-expect {
-    -re "Press ENTER for default.*443.*:" {
-        send "\r"
-    }
+expect -re "Press ENTER for default.*443.*:" {
+    send "\r"
 }
 
-# 클라이언트 트래픽 VPN 라우팅 - NO 답변
 expect "Should client traffic be routed by default through the VPN?"
-expect {
-    -re "Press ENTER for default.*yes.*:" {
-        send "no\r"
-    }
+expect -re "Press ENTER for default.*yes.*:" {
+    send "no\r"
 }
 
-# DNS 트래픽 VPN 라우팅 - NO 답변
 expect "Should client DNS traffic be routed by default through the VPN?"
-expect {
-    -re "Press ENTER for default.*yes.*:" {
-        send "no\r"
-    }
+expect -re "Press ENTER for default.*yes.*:" {
+    send "no\r"
 }
 
-# Private 서브넷 접근 허용
-expect {
-    "Should private subnets be accessible to clients by default?" {
-        expect -re "Press ENTER for default.*yes.*:"
-        send "\r"
-    }
+expect "Should private subnets be accessible to clients by default?" {
+    expect -re "Press ENTER for default.*yes.*:"
+    send "\r"
 }
 
-# Admin UI 로그인 계정 설정
-expect {
-    "Do you wish to login to the Admin UI as \"openvpn\"?" {
-        expect -re "Press ENTER for default.*yes.*:"
-        send "\r"
-    }
+expect "Do you wish to login to the Admin UI as \"openvpn\"?" {
+    expect -re "Press ENTER for default.*yes.*:"
+    send "\r"
 }
 
-# 🔧 패스워드 설정 부분 수정
-expect {
-    -re "Type a password.*if left blank.*:" {
-        send "\r"
-    }
-    -re "Type a password.*:" {
-        send "\r"
-    }
+expect -re "Type a password.*:" {
+    send "\r"
 }
 
-# 🔧 패스워드 확인 부분 수정
-expect {
-    -re "Confirm.*password.*:" {
-        send  "\r"
-    }
-    -re ".*Confirm.*:" {
-        send  "\r"
-    }
+expect -re ".*Activation key.*:" {
+    send "\r"
 }
 
-# Activation Key 처리
-expect {
-    -re "specify your Activation key.*:" {
-        if {$activation_key eq ""} {
-            send "\r"
-        } else {
-            send "$activation_key\r"
-        }
-    }
-    -re "Activation key.*:" {
-        if {$activation_key eq ""} {
-            send "\r"
-        } else {
-            send "$activation_key\r"
-        }
-    }
-}
-
-# 설정 완료 대기
 expect {
     -re "successfully installed" {
-        puts "\n=== OpenVPN Access Server 설치 완료! ==="
-    }
-    -re "configuration complete" {
-        puts "\n=== 설정 완료! ==="
+        puts "\n=== Installation completed ==="
     }
     eof {
-        puts "\n=== 설정 프로세스 종료 ==="
+        puts "\n=== Process finished ==="
     }
-}
 
-EOF
+}
+EXPECTSCRIPT
 
 sudo chmod +x /root/auto-ovpn-init.expect
+echo "[INFO] Running OpenVPN initialization..."
 sudo /root/auto-ovpn-init.expect
 
-
-# 2. 서비스 시작
+echo "[INFO] Starting OpenVPN service..."
 sudo service openvpnas start
 
-# 3. 서비스가 완전히 뜰 때까지 대기
-echo "OpenVPN 서비스가 시작될 때까지 대기 중..."
+echo "[INFO] Waiting for service to be ready..."
 for i in {1..30}; do
     if sudo netstat -tnlp | grep -q ':943'; then
-        echo "OpenVPN admin port opened!"
+        echo "[INFO] OpenVPN admin port is ready"
         break
     fi
     sleep 1
 done
 
-# 4. 관리자 비밀번호 재설정 보장
+echo "[INFO] Setting admin password..."
 sudo /usr/local/openvpn_as/scripts/sacli --user openvpn --new_pass "$CUSTOM_PASSWORD" SetLocalPassword
 
-# 간단한 수정 스크립트 생성 및 실행
-sudo tee /root/fix-openvpn-ip.sh > /dev/null << 'EOF'
+echo "[INFO] Configuring external IP settings..."
+sudo tee /root/fix-openvpn-ip.sh > /dev/null << 'IPFIXSCRIPT'
 #!/bin/bash
 EXTERNAL_IP=$(curl -s ifconfig.me)
-echo "[INFO] 외부 IP: $EXTERNAL_IP 로 설정 중..."
+echo "[INFO] Setting external IP: $EXTERNAL_IP"
 
 sudo /usr/local/openvpn_as/scripts/sacli --key "host.name" --value "$EXTERNAL_IP" ConfigPut
 sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.daemon.0.listen.ip" --value "all" ConfigPut
 sudo /usr/local/openvpn_as/scripts/sacli --key "admin_ui.https.ip_address" --value "all" ConfigPut
 sudo /usr/local/openvpn_as/scripts/sacli --key "cs.https.ip_address" --value "all" ConfigPut
+
 sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.server.reroute_gw" --value "false" ConfigPut
 sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.server.reroute_dns" --value "false" ConfigPut
 sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.client.routing.reroute_gw" --value "false" ConfigPut
 sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.client.routing.reroute_dns" --value "false" ConfigPut
 
-sudo ufw allow 1194/udp 2>/dev/null
-sudo ufw allow 943/tcp 2>/dev/null
+sudo ufw allow 1194/udp 2>/dev/null || true
+sudo ufw allow 943/tcp 2>/dev/null || true
 
 sudo /usr/local/openvpn_as/scripts/sacli start
-
-echo "[INFO] 완료! Admin UI: https://$EXTERNAL_IP:943/admin"
-EOF
+echo "[INFO] External IP configuration completed"
+IPFIXSCRIPT
 
 sudo chmod +x /root/fix-openvpn-ip.sh
 sudo /root/fix-openvpn-ip.sh
 
-# VPN Private Networks 설정
+echo "[INFO] Configuring VPN private networks..."
 VPN_PRIVATE_NETWORKS="${vpn_private_networks}"
 if [ -n "$VPN_PRIVATE_NETWORKS" ]; then
+    echo "[INFO] Setting private networks: $VPN_PRIVATE_NETWORKS"
     IFS=',' read -ra SUBNETS <<< "$VPN_PRIVATE_NETWORKS"
     
     for i in "$${!SUBNETS[@]}"; do
-        CIDR="${SUBNETS[$i]}"
+        CIDR="$${SUBNETS[$${i}]}"
         if [[ -n "$CIDR" ]]; then
-            echo "  - $CIDR"
+            echo "[INFO] Adding network: $CIDR"
             sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.server.routing.private_network.$${i}" --value "$CIDR" ConfigPut
         fi
     done
 fi
 
+echo "[INFO] Restarting OpenVPN service..."
 sudo service openvpnas restart
 
-# 7. 정보 저장 (여기서 생성됨!)
-sudo tee /root/openvpn-info.txt > /dev/null <<EOF
-[OpenVPN Access Server 정보]
+echo "[INFO] Saving connection information..."
+sudo tee /root/openvpn-info.txt > /dev/null << INFOFILE
+OpenVPN Access Server Information
 
-관리자 UI: https://$SERVER_IP:943/admin
-클라이언트 UI: https://$SERVER_IP:943/
-사용자: openvpn
-비밀번호: $CUSTOM_PASSWORD
+Admin UI: https://$SERVER_IP:943/admin
+Client UI: https://$SERVER_IP:943/
+Username: openvpn
+Password: $CUSTOM_PASSWORD
 
-로그 위치:
-  /var/log/openvpnas.log
-  /usr/local/openvpn_as/log/openvpn.log
+External IP: $SERVER_IP
+Internal IP: $INTERNAL_IP
 
-VPN 포트: UDP 1194
-웹 포트: TCP 443 (Client), TCP 943 (Admin)
-EOF
+VPN Port: UDP 1194
+Web Ports: TCP 443 (Client), TCP 943 (Admin)
+
+Installation completed: $(date)
+INFOFILE
 
 sudo chmod 600 /root/openvpn-info.txt
 
-# 8. 커널 포워딩 설정
-echo "시스템 최적화 설정 적용 중..."
+echo "[INFO] Enabling IP forwarding..."
 echo 'net.ipv4.ip_forward = 1' | sudo tee -a /etc/sysctl.conf
 sudo sysctl -p
 
-echo "[INFO] 설치 완료. 접속: https://$SERVER_IP:943/admin"
+echo "======================================================"
+echo "[SUCCESS] OpenVPN installation completed!"
+echo "Admin UI: https://$SERVER_IP:943/admin"
+echo "Username: openvpn"
+echo "Password: $CUSTOM_PASSWORD"
+echo "======================================================"

--- a/terraform/gcp/environments/shared/scripts/install-openvpn.sh.tpl
+++ b/terraform/gcp/environments/shared/scripts/install-openvpn.sh.tpl
@@ -227,7 +227,18 @@ EOF
 sudo chmod +x /root/fix-openvpn-ip.sh
 sudo /root/fix-openvpn-ip.sh
 
+# 내부망(서브넷) 자동 라우팅 등록
+VPN_PRIVATE_NETWORKS="${vpn_private_networks:-""}"
+IFS=',' read -ra SUBNETS <<< "$VPN_PRIVATE_NETWORKS"
 
+echo "[INFO] OpenVPN 라우팅에 아래 CIDR들을 추가합니다:"
+for i in "${!SUBNETS[@]}"; do
+    CIDR="${SUBNETS[$i]}"
+    if [[ -n "$CIDR" ]]; then
+        echo "  - $CIDR"
+        sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.server.routing.private_network.${i}" --value "$CIDR" ConfigPut
+    fi
+done
 
 # 6. 서비스 재시작
 sudo service openvpnas restart

--- a/terraform/gcp/environments/shared/variables.tf
+++ b/terraform/gcp/environments/shared/variables.tf
@@ -51,3 +51,10 @@ variable "vpn_client_cidr_blocks" {
   description = "OpenVPN 서버 또는 클라이언트 IP 대역"
   type        = list(string)
 }
+
+# variables.tf
+variable "vpn_private_networks" {
+  description = "VPN을 통해 접근 가능한 내부망(서브넷) CIDR 목록"
+  type        = list(string)
+  default     = []
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- private, nat 서브넷 대역을 라우팅 하도록 수정

## 📋 상세 설명

# 내부망(서브넷) 자동 라우팅 등록
```
VPN_PRIVATE_NETWORKS="${vpn_private_networks:-""}"
IFS=',' read -ra SUBNETS <<< "$VPN_PRIVATE_NETWORKS"

echo "[INFO] OpenVPN 라우팅에 아래 CIDR들을 추가합니다:"
for i in "${!SUBNETS[@]}"; do
    CIDR="${SUBNETS[$i]}"
    if [[ -n "$CIDR" ]]; then
        echo "  - $CIDR"
        sudo /usr/local/openvpn_as/scripts/sacli --key "vpn.server.routing.private_network.${i}" --value "$CIDR" ConfigPut
    fi
done
```

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.