### PR TITLE
feat: 고정 IP 추가 , destroy_prevent 추가

### DIFF
--- a/terraform/gcp/environments/shared/main.tf
+++ b/terraform/gcp/environments/shared/main.tf
@@ -13,6 +13,104 @@ provider "google" {
 
 }
 
+
+module "network" {
+  source           = "../../modules/network"
+  project_id       = var.dev_gcp_project_id
+  region           = var.region
+  vpc_name         = var.vpc_name
+  public_subnets   = local.public_subnets
+  private_subnets  = local.private_subnets
+  nat_subnets      = local.nat_subnets
+}
+
+
+
+
+
+
+module "firewall" {
+  source         = "../../modules/firewall"
+  vpc_name       = module.network.vpc_name
+  firewall_rules = local.firewall_rules
+}
+
+
+
+locals {
+  vpn_private_networks = concat(
+    [for s in local.private_subnets : s.cidr],
+    [for s in local.nat_subnets : s.cidr]
+  )
+}
+
+resource "google_compute_address" "openvpn_static_ip" {
+  name = "openvpn-static-ip"
+  region = var.region
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+
+resource "google_compute_instance" "openvpn" {
+  name                  = "openvpn"
+  machine_type          = "e2-small"
+  zone                  = "asia-east1-b"
+  tags                  = ["openvpn", "openvpn-console", "allow-ssh-http"]  
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+      size  = 10
+    }
+  }
+  network_interface {
+    subnetwork =  module.network.subnets["${var.vpc_name}-public-b"].self_link
+
+    # enable_public_ip 가 true일 때만 access_config 블록을 생성
+    dynamic "access_config" {
+        for_each = [1] # 또는 enable_public_ip ? [1] : []
+        content {
+        nat_ip = google_compute_address.openvpn_static_ip.address
+        }  
+    }
+  }
+
+  metadata_startup_script = local.startup_script
+
+  service_account {
+    email  = var.default_sa_email
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+
+module "backend" {
+    source                = "../../modules/compute"
+    name                  = "backend"
+    machine_type          = "e2-medium"
+    zone                  = "asia-east1-b"
+    image                 = "ubuntu-os-cloud/ubuntu-2204-lts"
+    disk_size_gb          = 10
+    tags                  = ["allow-vpn-ssh"]
+    
+    subnetwork            = module.network.subnets["${var.vpc_name}-nat-b"].self_link
+    
+    # ✅ deploy 계정의 SSH 키는 base-init.sh.tpl에서 사용됨
+    deploy_ssh_public_key = var.ssh_private_key
+    
+    service_account_email  = var.default_sa_email
+    service_account_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+   
+}
+
+
+
 locals {
   public_subnets = [
     {
@@ -58,21 +156,8 @@ locals {
       component                = "nat"
     }
   ]
-}
 
-module "shared_network" {
-  source           = "../../modules/network"
-  project_id       = var.dev_gcp_project_id
-  region           = var.region
-  vpc_name         = var.vpc_name
-  public_subnets   = local.public_subnets
-  private_subnets  = local.private_subnets
-  nat_subnets      = local.nat_subnets
-}
-
-
-locals {
-  firewall_rules = [
+    firewall_rules = [
     {
       name          = "ingress-public"
       env           = var.env
@@ -133,85 +218,20 @@ locals {
   ]
 }
 
-module "firewall" {
-  source         = "../../modules/firewall"
-  vpc_name       = module.network.vpc_name
-  firewall_rules = local.firewall_rules
-}
-
-
-
 locals {
-  vpn_private_networks = concat(
-    [for s in local.private_subnets : s.cidr],
-    [for s in local.nat_subnets : s.cidr]
-  )
-}
-
-resource "google_compute_address" "openvpn_static_ip" {
-  name = "openvpn-static-ip"
-  region = var.region
-  lifecycle {
-    prevent_destroy = true
-  }
+  startup_script = join("\n", [
+    templatefile("../../modules/compute/scripts/base-init.sh.tpl", {
+      deploy_ssh_public_key = var.ssh_private_key
+    }),
+    templatefile("${path.module}/scripts/install-openvpn.sh.tpl", {
+      openvpn_admin_password = var.openvpn_admin_password,
+      vpn_private_networks   = join(",", local.vpn_private_networks)
+    })
+  ])
 }
 
 
-resource "google_compute_instance" "openvpn" {
-  name                  = "openvpn"
-  machine_type          = "e2-small"
-  zone                  = "asia-east1-b"
-  tags                  = ["openvpn", "openvpn-console", "allow-ssh-http"]  
 
-  boot_disk {
-    initialize_params {
-      image = "ubuntu-os-cloud/ubuntu-2204-lts"
-      size  = 10
-    }
-  }
-  network_interface {
-    subnetwork =  module.network.subnets["${var.vpc_name}-public-b"].self_link
-
-    # enable_public_ip 가 true일 때만 access_config 블록을 생성
-    dynamic "access_config" {
-        for_each = [1] # 또는 enable_public_ip ? [1] : []
-        content {
-        nat_ip = google_compute_address.openvpn_static_ip.address
-        }  
-    }
-  }
-
-  metadata_startup_script = module.compute.startup_script
-
-  service_account {
-    email  = var.default_sa_email
-    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-  }
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
-
-module "backend" {
-    source                = "../../modules/compute"
-    name                  = "backend"
-    machine_type          = "e2-medium"
-    zone                  = "asia-east1-b"
-    image                 = "ubuntu-os-cloud/ubuntu-2204-lts"
-    disk_size_gb          = 10
-    tags                  = ["allow-vpn-ssh"]
-    
-    subnetwork            = module.network.subnets["${var.vpc_name}-nat-b"].self_link
-    
-    # ✅ deploy 계정의 SSH 키는 base-init.sh.tpl에서 사용됨
-    deploy_ssh_public_key = var.ssh_private_key
-    
-    service_account_email  = var.default_sa_email
-    service_account_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-
-}
 
 
 

--- a/terraform/gcp/environments/shared/main.tf
+++ b/terraform/gcp/environments/shared/main.tf
@@ -1,13 +1,11 @@
 terraform {
   backend "remote" {
     organization = "hertz-tuning"
-
     workspaces {
       name = "gcp-shared"
     }
   }
 }
-
 provider "google" {
   credentials = var.dev_gcp_sa_key
   project = var.dev_gcp_project_id
@@ -70,7 +68,6 @@ module "shared_network" {
   public_subnets   = local.public_subnets
   private_subnets  = local.private_subnets
   nat_subnets      = local.nat_subnets
-  prevent_destroy = true
 }
 
 
@@ -121,18 +118,18 @@ locals {
     source_ranges = ["0.0.0.0/0"]
     target_tags   = ["openvpn"]
     description   = "Allow OpenVPN admin and client web access"
-},
-{
-  name          = "ssh-from-vpn"
-  env           = var.env
-  direction     = "INGRESS"
-  priority      = 1003
-  protocol      = "tcp"
-  ports         = ["22"]
-  source_ranges = var.vpn_client_cidr_blocks 
-  target_tags   = ["allow-vpn-ssh"]
-  description   = "Allow SSH from VPN clients"
-}
+    },
+    {
+    name          = "ssh-from-vpn"
+    env           = var.env
+    direction     = "INGRESS"
+    priority      = 1003
+    protocol      = "tcp"
+    ports         = ["22"]
+    source_ranges = var.vpn_client_cidr_blocks 
+    target_tags   = ["allow-vpn-ssh"]
+    description   = "Allow SSH from VPN clients"
+    }
   ]
 }
 
@@ -159,6 +156,66 @@ resource "google_compute_address" "openvpn_static_ip" {
   }
 }
 
+
+resource "google_compute_instance" "openvpn" {
+  name                  = "openvpn"
+  machine_type          = "e2-small"
+  zone                  = "asia-east1-b"
+  tags                  = ["openvpn", "openvpn-console", "allow-ssh-http"]  
+
+  boot_disk {
+    initialize_params {
+      image = "ubuntu-os-cloud/ubuntu-2204-lts"
+      size  = 10
+    }
+  }
+  network_interface {
+    subnetwork =  module.network.subnets["${var.vpc_name}-public-b"].self_link
+
+    # enable_public_ip 가 true일 때만 access_config 블록을 생성
+    dynamic "access_config" {
+        for_each = [1] # 또는 enable_public_ip ? [1] : []
+        content {
+        nat_ip = google_compute_address.openvpn_static_ip.address
+        }  
+    }
+  }
+
+  metadata_startup_script = module.compute.startup_script
+
+  service_account {
+    email  = var.default_sa_email
+    scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  }
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+
+module "backend" {
+    source                = "../../modules/compute"
+    name                  = "backend"
+    machine_type          = "e2-medium"
+    zone                  = "asia-east1-b"
+    image                 = "ubuntu-os-cloud/ubuntu-2204-lts"
+    disk_size_gb          = 10
+    tags                  = ["allow-vpn-ssh"]
+    
+    subnetwork            = module.network.subnets["${var.vpc_name}-nat-b"].self_link
+    
+    # ✅ deploy 계정의 SSH 키는 base-init.sh.tpl에서 사용됨
+    deploy_ssh_public_key = var.ssh_private_key
+    
+    service_account_email  = var.default_sa_email
+    service_account_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+
+}
+
+
+
+/*
 module "bastion_openvpn" {
   source                = "../../modules/compute"
   name                  = "openvpn"
@@ -182,27 +239,4 @@ module "bastion_openvpn" {
 
   service_account_email  = var.default_sa_email
   service_account_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-  prevent_destroy        = true
-}
-
-module "backend" {
-    source                = "../../modules/compute"
-    name                  = "backend"
-    machine_type          = "e2-medium"
-    zone                  = "asia-east1-b"
-    image                 = "ubuntu-os-cloud/ubuntu-2204-lts"
-    disk_size_gb          = 10
-    tags                  = ["allow-vpn-ssh"]
-    
-    subnetwork            = module.network.subnets["${var.vpc_name}-nat-b"].self_link
-    
-    # ✅ deploy 계정의 SSH 키는 base-init.sh.tpl에서 사용됨
-    deploy_ssh_public_key = var.ssh_private_key
-    
-    service_account_email  = var.default_sa_email
-    service_account_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
-    
-    
-    prevent_destroy        = false
-
-}
+}*/

--- a/terraform/gcp/environments/shared/main.tf
+++ b/terraform/gcp/environments/shared/main.tf
@@ -62,7 +62,7 @@ locals {
   ]
 }
 
-module "network" {
+module "shared_network" {
   source           = "../../modules/network"
   project_id       = var.dev_gcp_project_id
   region           = var.region
@@ -70,6 +70,7 @@ module "network" {
   public_subnets   = local.public_subnets
   private_subnets  = local.private_subnets
   nat_subnets      = local.nat_subnets
+  prevent_destroy = true
 }
 
 
@@ -153,6 +154,9 @@ locals {
 resource "google_compute_address" "openvpn_static_ip" {
   name = "openvpn-static-ip"
   region = var.region
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 module "bastion_openvpn" {
@@ -178,6 +182,7 @@ module "bastion_openvpn" {
 
   service_account_email  = var.default_sa_email
   service_account_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+  prevent_destroy        = true
 }
 
 module "backend" {
@@ -196,5 +201,8 @@ module "backend" {
     
     service_account_email  = var.default_sa_email
     service_account_scopes = ["https://www.googleapis.com/auth/cloud-platform"]
+    
+    
+    prevent_destroy        = false
 
 }

--- a/terraform/gcp/modules/compute/main.tf
+++ b/terraform/gcp/modules/compute/main.tf
@@ -11,7 +11,6 @@ resource "google_compute_instance" "vm" {
       size  = var.disk_size_gb
     }
   }
-
   network_interface {
     subnetwork = var.subnetwork
 
@@ -41,3 +40,4 @@ locals {
     var.extra_startup_script
   ])
 }
+

--- a/terraform/gcp/modules/compute/main.tf
+++ b/terraform/gcp/modules/compute/main.tf
@@ -18,7 +18,10 @@ resource "google_compute_instance" "vm" {
     # enable_public_ip 가 true일 때만 access_config 블록을 생성
     dynamic "access_config" {
       for_each = var.enable_public_ip ? [1] : []
-      content {}
+      content {
+        # static_ip(고정 IP)가 있으면 그걸 쓰고, 없으면 임시 IP
+        nat_ip = var.static_ip != "" ? var.static_ip : null
+      }
     }
   }
 

--- a/terraform/gcp/modules/compute/output.tf
+++ b/terraform/gcp/modules/compute/output.tf
@@ -1,0 +1,7 @@
+output "startup_script" {
+  value = local.startup_script
+}
+
+output "instance_ip" {
+  value = google_compute_instance.vm.network_interface[0].network_ip
+}

--- a/terraform/gcp/modules/firewall/main.tf
+++ b/terraform/gcp/modules/firewall/main.tf
@@ -17,4 +17,12 @@ resource "google_compute_firewall" "rules" {
   source_ranges = each.value.source_ranges
   target_tags   = each.value.target_tags
   description   = each.value.description
+  lifecycle {
+    prevent_destroy = true
+  }
 }
+
+
+
+
+

--- a/terraform/gcp/modules/firewall/variables.tf
+++ b/terraform/gcp/modules/firewall/variables.tf
@@ -1,10 +1,5 @@
-variable "vpc_name" {
-  description = "VPC 이름"
-  type        = string
-}
-
+variable "vpc_name" { type = string }
 variable "firewall_rules" {
-  description = "방화벽 규칙 리스트"
   type = list(object({
     name          = string
     env           = string

--- a/terraform/gcp/modules/network/main.tf
+++ b/terraform/gcp/modules/network/main.tf
@@ -2,6 +2,9 @@ resource "google_compute_network" "vpc" {
   name                    = var.vpc_name
   auto_create_subnetworks = false
   routing_mode            = "REGIONAL"
+  lifecycle {
+    prevent_destroy = var.prevent_destroy
+  }
 }
 
 # Subnet 공통 생성 - public / private / nat 태그로 분리
@@ -17,6 +20,9 @@ resource "google_compute_subnetwork" "subnets" {
   network       = google_compute_network.vpc.id
 
   private_ip_google_access = each.value.private_ip_google_access
+  lifecycle {
+    prevent_destroy = var.prevent_destroy
+  }
 
 }
 

--- a/terraform/gcp/modules/network/main.tf
+++ b/terraform/gcp/modules/network/main.tf
@@ -3,7 +3,7 @@ resource "google_compute_network" "vpc" {
   auto_create_subnetworks = false
   routing_mode            = "REGIONAL"
   lifecycle {
-    prevent_destroy = var.prevent_destroy
+    prevent_destroy = true
   }
 }
 
@@ -20,8 +20,8 @@ resource "google_compute_subnetwork" "subnets" {
   network       = google_compute_network.vpc.id
 
   private_ip_google_access = each.value.private_ip_google_access
-  lifecycle {
-    prevent_destroy = var.prevent_destroy
+    lifecycle {
+    prevent_destroy = true
   }
 
 }

--- a/terraform/gcp/modules/network/variables.tf
+++ b/terraform/gcp/modules/network/variables.tf
@@ -39,3 +39,10 @@ variable "nat_subnets" {
   }))
   default = []
 }
+
+variable "prevent_destroy" {
+  type    = bool
+  default = false
+  description = "If true, prevents the destruction of the network resources. Useful for production environments."
+  
+}


### PR DESCRIPTION
## 🔗 관련 이슈
[Sprint #5 - CL] - gcp-openvpn
[#249](https://github.com/100-hours-a-week/2-hertz-wiki/issues/249)

## ✏️ 변경 사항
- openvpn 서버에 고정 IP를 생성하고 destroy_prevent를 추가

## 📋 상세 설명
- openvpn은 destroy 하지 않고 수동으로 중지하여 기존의 세팅이 초기화 되는 것을 방지 하는 운영을 위해

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.