### PR TITLE
fix: proxy only subnet, external alb 수정

### DIFF
--- a/terraform/gcp/environments/develop/main.tf
+++ b/terraform/gcp/environments/develop/main.tf
@@ -147,11 +147,29 @@ module "backend_internal_asg_green" {
 # 백엔드 Internal Load Balancer (8080)
 ############################################################
 
+resource "google_compute_subnetwork" "ilb_proxy_subnet" {
+  name          = "${var.vpc_name}-ilb-proxy-subnet"
+  ip_cidr_range = var.proxy_subnet_cidr #"10.10.31.0/28"             # 원하는 CIDR(내부 IP 풀)
+  region        = var.region                 # 예: asia-east1
+  network       = local.vpc_self_link          # VPC self_link
+
+  # ────────────────────────────────────────────────────
+  # 서브넷 용도를 "Internal HTTPS Load Balancer" 용도로 지정
+  # 이 옵션이 있어야 프록시 전용 모드(subnet role)가 활성화됨
+  purpose                         = "INTERNAL_HTTPS_LOAD_BALANCER"
+  private_ip_google_access        = true    # 필요 시 활성화
+  # role: 자동 부여되므로 따로 설정할 필요 없음
+  # ────────────────────────────────────────────────────
+}
+
+
 module "backend_internal_lb" {
   source                = "../../modules/internal-http-lb"
   region                = var.region
   subnet_self_link      = local.subnet_self_link
   vpc_self_link         = data.terraform_remote_state.shared.outputs.vpc_self_link
+  proxy_subnet_self_link = google_compute_subnetwork.ilb_proxy_subnet.self_link
+
   backend_name_prefix   = "backend-internal-lb"
   backends = [
     {

--- a/terraform/gcp/environments/develop/main.tf
+++ b/terraform/gcp/environments/develop/main.tf
@@ -149,7 +149,7 @@ module "backend_internal_asg_green" {
 
 resource "google_compute_subnetwork" "ilb_proxy_subnet" {
   name          = "${var.vpc_name}-ilb-proxy-subnet"
-  ip_cidr_range = var.proxy_subnet_cidr #"10.10.31.0/28"             # 원하는 CIDR(내부 IP 풀)
+  ip_cidr_range = var.proxy_subnet_cidr 
   region        = var.region                 # 예: asia-east1
   network       = local.vpc_self_link          # VPC self_link
 

--- a/terraform/gcp/environments/develop/variable.tf
+++ b/terraform/gcp/environments/develop/variable.tf
@@ -105,3 +105,11 @@ variable "docker_image_front_green" {
   type        = string
   default = "gcr.io/proj/frontend:green"
 }
+
+variable "proxy_subnet_cidr" {
+  
+  type = string
+  description = "프록시 서브넷 CIDR (예:"
+  default = ""
+  
+}

--- a/terraform/gcp/environments/develop/variable.tf
+++ b/terraform/gcp/environments/develop/variable.tf
@@ -110,6 +110,5 @@ variable "proxy_subnet_cidr" {
   
   type = string
   description = "프록시 서브넷 CIDR (예:"
-  default = ""
-  
+  default     = "10.10.31.0/28"
 }

--- a/terraform/gcp/modules/external-https-lb/main.tf
+++ b/terraform/gcp/modules/external-https-lb/main.tf
@@ -13,19 +13,37 @@ resource "google_compute_managed_ssl_certificate" "this" {
 
 resource "google_compute_url_map" "this" {
   name            = "${var.name}-url-map"
-  default_service = var.frontend_service
 
+  # ───────────────────────────────────────────────────────────────────
+  # 1) host_rule: 어떤 도메인/호스트 이름에 대해 이 URL Map을 적용할 것인지
+  #    만약 “모든 호스트(와일드카드)”로 적용하고 싶다면 “*” 사용
+  #    또는 특정 도메인만 묶고 싶다면 ["app.example.com"] 등으로 지정
+  # ───────────────────────────────────────────────────────────────────
+  host_rule {
+    hosts        = ["*"]                     # 모든 호스트(와일드카드)
+    path_matcher = "main-matcher"            # 아래 path_matcher 이름과 동일해야 함
+  }
+
+  # ───────────────────────────────────────────────────────────────────
+  # 2) path_matcher: 경로(/api/* 등)에 따라 어떤 BackendService로 보낼지
+  # ───────────────────────────────────────────────────────────────────
   path_matcher {
     name            = "main-matcher"
-    default_service = var.frontend_service
+    default_service = var.frontend_service      # 기본(예: "/") 요청을 받을 서비스
 
     path_rule {
-      paths   = ["/api/*"]
-      service = var.backend_service
+      paths   = ["/api/*"]                     # /api/로 시작하는 모든 URL
+      service = var.backend_service            # /api/* 요청은 backend_service로 보냄
     }
   }
-}
 
+  # ───────────────────────────────────────────────────────────────────
+  # 3) default_service: 만약 호스트/경로 매칭이 전혀 안 되는 요청이 들어올 경우
+  #    최종적으로 어떤 서비스로 보낼지 지정
+  #    (보통 “front엔드” 혹은 404 페이지 용으로 간단히 잡아둠)
+  # ───────────────────────────────────────────────────────────────────
+  default_service = var.frontend_service
+}
 
 resource "google_compute_target_https_proxy" "this" {
   name             = "${var.name}-https-proxy"

--- a/terraform/gcp/modules/internal-http-lb/main.tf
+++ b/terraform/gcp/modules/internal-http-lb/main.tf
@@ -42,7 +42,7 @@ resource "google_compute_region_target_http_proxy" "this" {
 resource "google_compute_address" "internal_ip" {
   name         = "${var.backend_name_prefix}-ip"
   address_type = "INTERNAL"
-  subnetwork   = var.subnet_self_link
+ subnetwork   = var.proxy_subnet_self_link
   region       = var.region
 }
 
@@ -50,7 +50,7 @@ resource "google_compute_forwarding_rule" "this" {
   name                  = "${var.backend_name_prefix}-fr"
   load_balancing_scheme = "INTERNAL_MANAGED"
   network               = var.vpc_self_link
-  subnetwork            = var.subnet_self_link
+  subnetwork            = var.proxy_subnet_self_link 
   ip_address            = google_compute_address.internal_ip.address
   ports                 = [var.port]      # 리스트 형식
   target                = google_compute_region_target_http_proxy.this.self_link

--- a/terraform/gcp/modules/internal-http-lb/variables.tf
+++ b/terraform/gcp/modules/internal-http-lb/variables.tf
@@ -63,3 +63,8 @@ variable "ip_prefix_length" {
 }
 
 
+// ▶ Proxy-Only Subnet의 self_link를 받아올 변수
+variable "proxy_subnet_self_link" {
+  description = "Internal HTTP LB 프록시 전용 서브넷(Proxy-Only Subnet) self_link"
+  type        = string
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
-  proxy only subnet 추가
- external alb url-map matches 수정

## 📋 상세 설명

```
resource "google_compute_subnetwork" "ilb_proxy_subnet" {
  name          = "${var.vpc_name}-ilb-proxy-subnet"
  ip_cidr_range = var.proxy_subnet_cidr #"10.10.31.0/28"             # 원하는 CIDR(내부 IP 풀)
  region        = var.region                 # 예: asia-east1
  network       = local.vpc_self_link          # VPC self_link

  # ────────────────────────────────────────────────────
  # 서브넷 용도를 "Internal HTTPS Load Balancer" 용도로 지정
  # 이 옵션이 있어야 프록시 전용 모드(subnet role)가 활성화됨
  purpose                         = "INTERNAL_HTTPS_LOAD_BALANCER"
  private_ip_google_access        = true    # 필요 시 활성화
  # role: 자동 부여되므로 따로 설정할 필요 없음
  # ────────────────────────────────────────────────────
}
```

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.