### PR TITLE
fix: MIG 서비스에 헬스체크 초기 지연 시간 변경(60 -> 300초)

### DIFF
--- a/terraform/gcp/modules/mig-asg/main.tf
+++ b/terraform/gcp/modules/mig-asg/main.tf
@@ -40,7 +40,7 @@ resource "google_compute_region_instance_group_manager" "this" {
 
   auto_healing_policies {
     health_check      = var.health_check
-    initial_delay_sec = 60
+    initial_delay_sec = 300
   }
 }
 


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- MIG 서비스에 헬스체크 초기 지연 시간 변경(60 -> 300초)

## 📋 상세 설명
- `initial_delay_sec = 60` -> `initial_delay_sec = 300`

## ✅ 체크리스트
- [ ] CD 테스트를 위한 PR 머지

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.