### PR TITLE
fix: 헬스체크 시간(300 -> 420초) 및 blue asg 인스턴스 수(min 0, max 0) 변경

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,6 +68,14 @@ override.tf.json
 # Ignore transient lock info files created by terraform apply
 .terraform.tfstate.lock.info
 **/.terraform.tfstate.lock.info
+.terraform/
+*.tfstate
+*.tfstate.backup
+*.tfvars
+*.auto.tfvars
+.env*
+.terraform.lock.hcl
+crash.log
 
 # Include override files you do wish to add to version control using negated pattern
 # !example_override.tf
@@ -80,3 +88,4 @@ override.tf.json
 terraform.rc
 
 .secrets
+

--- a/terraform/gcp/environments/prod/variable.tf
+++ b/terraform/gcp/environments/prod/variable.tf
@@ -158,8 +158,8 @@ variable "blue_instance_count" {
   })
   default = {
     # desired = 1
-    min     = 1
-    max     = 2
+    min     = 0
+    max     = 0
   }
 }
 

--- a/terraform/gcp/modules/mig-asg/main.tf
+++ b/terraform/gcp/modules/mig-asg/main.tf
@@ -40,7 +40,7 @@ resource "google_compute_region_instance_group_manager" "this" {
 
   auto_healing_policies {
     health_check      = var.health_check
-    initial_delay_sec = 300
+    initial_delay_sec = 420
   }
 }
 


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- 헬스체크 시간(300 -> 420초) 및 blue asg 인스턴스 수(min 0, max 0) 변경
- 인스턴스 초기 세팅 시간이 300초로 부족하여 대기시간 증가
- 초기 apply 시, blue asg의 인스턴스의 필요성이 없기 때문에 min 0, max 0으로 변경하여 미생성

## 📋 상세 설명
- 헬스체크 시간 변경: 300 -> 420초
- blue asg 인스턴스 수 변경: min 1, max 2 -> min 0, max 0

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.