### PR TITLE
fix: DB 인스턴스에 백엔드 서버가 scp 접속 가능하도록 수정, mount point 수정

### DIFF
--- a/terraform/gcp/environments/develop/main.tf
+++ b/terraform/gcp/environments/develop/main.tf
@@ -286,8 +286,8 @@ resource "google_compute_instance" "mysql_vm" {
 
   network_interface {
     network    = local.vpc_self_link
-    subnetwork = local.private_subnet_self_link
-    network_ip = google_compute_address.mysql_internal_ip.address
+    subnetwork = local.subnet_self_link//local.private_subnet_self_link
+   // network_ip = google_compute_address.mysql_internal_ip.address
     # 외부 접근 필요 없으면 access_config 생략
   }
 

--- a/terraform/gcp/environments/develop/main.tf
+++ b/terraform/gcp/environments/develop/main.tf
@@ -286,8 +286,8 @@ resource "google_compute_instance" "mysql_vm" {
 
   network_interface {
     network    = local.vpc_self_link
-    subnetwork = local.subnet_self_link//local.private_subnet_self_link
-   // network_ip = google_compute_address.mysql_internal_ip.address
+    subnetwork = local.private_subnet_self_link
+    network_ip = google_compute_address.mysql_internal_ip.address
     # 외부 접근 필요 없으면 access_config 생략
   }
 

--- a/terraform/gcp/environments/develop/main.tf
+++ b/terraform/gcp/environments/develop/main.tf
@@ -359,7 +359,17 @@ locals {
       target_tags  = ["redis"]
       protocol     = "tcp"
       ports        = ["6379"]
-    }
+    },
+    {
+  name         = "${var.vpc_name}-fw-backend-to-mysql-ssh"
+  direction    = "INGRESS"
+  priority     = 1000
+  description  = "Allow backend VM to SSH/SCP to MySQL VM"
+  source_tags  = ["backend"]
+  target_tags  = ["mysql"]
+  protocol     = "tcp"
+  ports        = ["22"]
+}
   ]
 
   # 3) 두 리스트를 합쳐서 최종 firewall_rules 로 사용

--- a/terraform/gcp/environments/develop/main.tf
+++ b/terraform/gcp/environments/develop/main.tf
@@ -108,7 +108,8 @@ resource "google_compute_instance" "backend_vm" {
   metadata_startup_script = join("\n", [
     # 1) 기존 템플릿 파일 호출
     templatefile("${path.module}/scripts/backend-install.sh.tpl", {
-      deploy_ssh_public_key = var.ssh_private_key
+      deploy_ssh_public_key = var.deploy_ssh_public_key
+      deploy_ssh_private_key= var.ssh_private_key
       docker_image          = var.docker_image_backend_blue
       use_ecr               = "true"
       aws_region            = var.aws_region
@@ -168,7 +169,7 @@ resource "google_compute_instance" "frontend_vm" {
 
   metadata_startup_script = join("\n", [
     templatefile("${path.module}/scripts/frontend-install.sh.tpl", {
-      deploy_ssh_public_key = var.ssh_private_key
+      deploy_ssh_public_key = var.deploy_ssh_public_key
       docker_image          = var.docker_image_front_blue
       use_ecr               = "true"
       aws_region            = var.aws_region

--- a/terraform/gcp/environments/develop/scripts/backend-install.sh.tpl
+++ b/terraform/gcp/environments/develop/scripts/backend-install.sh.tpl
@@ -9,6 +9,9 @@ echo "========== 기본 초기화 시작 =========="
 # deploy 사용자 생성 및 SSH 키 등록
 if id "deploy" &>/dev/null; then
   echo "[INFO] deploy 사용자 이미 존재함"
+  echo "${deploy_ssh_private_key}" > /home/deploy/.ssh/gcp_deploy_key
+  chmod 600 /home/deploy/.ssh/gcp_deploy_key
+  chown -R deploy:deploy /home/deploy/.ssh
 else
   echo "[INFO] deploy 사용자 생성 및 SSH 키 등록"
   useradd -m -s /bin/bash deploy

--- a/terraform/gcp/environments/develop/scripts/backend-install.sh.tpl
+++ b/terraform/gcp/environments/develop/scripts/backend-install.sh.tpl
@@ -14,8 +14,10 @@ else
   useradd -m -s /bin/bash deploy
   mkdir -p /home/deploy/.ssh
   echo "${deploy_ssh_public_key}" > /home/deploy/.ssh/authorized_keys
+  echo "${deploy_ssh_private_key}" > /home/deploy/.ssh/gcp_deploy_key
   chmod 700 /home/deploy/.ssh
   chmod 600 /home/deploy/.ssh/authorized_keys
+  chmod 600 /home/deploy/.ssh/gcp_deploy_key
   chown -R deploy:deploy /home/deploy/.ssh
 fi
 

--- a/terraform/gcp/environments/develop/scripts/db-install.sh.tpl
+++ b/terraform/gcp/environments/develop/scripts/db-install.sh.tpl
@@ -26,19 +26,9 @@ fi
 
 echo "[INFO] 기본 초기화 완료"
 
-# ──────────────────────────────────────────────────────────────────
-# 1) 디스크 포맷 및 마운트
-#    - 디스크가 이미 포맷되어 있지 않다면 포맷
-#    - 마운트 지점: /mnt/mysql-data (필요 시 /var/lib/mysql 로 변경)
-# ──────────────────────────────────────────────────────────────────
 
 DEVICE="/dev/disk/by-id/google-mysql-data"
-MOUNT_POINT="/mnt/mysql-data"
-
-# 디스크가 ext4로 포맷되지 않았다면 포맷
-if ! blkid $${DEVICE} | grep -q ext4; then
-  mkfs.ext4 -F $${DEVICE}
-fi
+MOUNT_POINT="/mnt/tmp"
 
 # 마운트 디렉토리 생성
 mkdir -p $${MOUNT_POINT}
@@ -51,11 +41,8 @@ fi
 # 즉시 마운트
 mount $${MOUNT_POINT}
 
-# ──────────────────────────────────────────────────────────────────
-# 2) MySQL 설치 및 데이터 디렉토리 변경
-#    - Docker로 MySQL 컨테이너 실행 시, 데이터 볼륨을 /mnt/mysql-data에 연결
-#    (컨테이너 내부의 /var/lib/mysql ↔ 호스트의 /mnt/mysql-data)
-# ──────────────────────────────────────────────────────────────────
+# 4. mysql-data 서브디렉토리 생성
+mkdir -p $MOUNT_POINT/mysql-data
 
 
 # 로그 설정
@@ -76,7 +63,7 @@ docker run -d \
   -e MYSQL_DATABASE="${db_name}" \
   -e MYSQL_USER="${user_name}" \
   -e MYSQL_PASSWORD="${rootpasswd}" \
-  -v $${MOUNT_POINT}:/var/lib/mysql \
+  -v $${MOUNT_POINT}/mysql-data:/var/lib/mysql \
   -p 3306:3306 \
   mysql:8.0
 

--- a/terraform/gcp/environments/develop/scripts/vm-install.sh.tpl
+++ b/terraform/gcp/environments/develop/scripts/vm-install.sh.tpl
@@ -109,6 +109,7 @@ else
     exit 1
 fi
 
+
 # 이미지 변수 설정 (ECR 이미지)
 export IMAGE="${docker_image}"
 echo "[INFO] ECR 이미지 사용: $IMAGE"

--- a/terraform/gcp/environments/develop/variable.tf
+++ b/terraform/gcp/environments/develop/variable.tf
@@ -37,6 +37,11 @@ variable "ssh_private_key" {
   description = "deploy 계정에 등록할 SSH 공개 키"
   type        = string
 }
+
+variable "deploy_ssh_public_key" {
+  description = "배포 계정에 등록할 SSH 공개 키"
+  type        = string
+}
 variable "extra_startup_script" {
   description = "추가 사용자 정의 startup script (예: OpenVPN 등)"
   type        = string

--- a/terraform/gcp/environments/prod/main.tf
+++ b/terraform/gcp/environments/prod/main.tf
@@ -112,7 +112,8 @@ module "backend_internal_asg_blue" {
   startup_tpl = join("\n", [
     # 기존 템플릿 파일 호출
       templatefile("${path.module}/scripts/backend-install.sh.tpl", {
-      deploy_ssh_public_key = var.ssh_private_key
+      deploy_ssh_public_key = var.deploy_ssh_public_key
+      deploy_ssh_private_key= var.ssh_private_key
       docker_image          = var.docker_image_backend_blue
       use_ecr               = "true"
       aws_region            = var.aws_region
@@ -150,7 +151,8 @@ module "backend_internal_asg_green" {
 
   startup_tpl = join("\n", [
     templatefile("${path.module}/scripts/backend-install.sh.tpl", {
-      deploy_ssh_public_key = var.ssh_private_key
+      deploy_ssh_public_key = var.deploy_ssh_public_key
+      deploy_ssh_private_key= var.ssh_private_key
       docker_image          = var.docker_image_backend_green
       use_ecr               = "true"
       aws_region            = var.aws_region

--- a/terraform/gcp/environments/prod/scripts/backend-install.sh.tpl
+++ b/terraform/gcp/environments/prod/scripts/backend-install.sh.tpl
@@ -14,8 +14,10 @@ else
   useradd -m -s /bin/bash deploy
   mkdir -p /home/deploy/.ssh
   echo "${deploy_ssh_public_key}" > /home/deploy/.ssh/authorized_keys
+  echo "${deploy_ssh_private_key}" > /home/deploy/.ssh/gcp_deploy_key
   chmod 700 /home/deploy/.ssh
   chmod 600 /home/deploy/.ssh/authorized_keys
+  chmod 600 /home/deploy/.ssh/gcp_deploy_key
   chown -R deploy:deploy /home/deploy/.ssh
 fi
 

--- a/terraform/gcp/environments/prod/scripts/backend-install.sh.tpl
+++ b/terraform/gcp/environments/prod/scripts/backend-install.sh.tpl
@@ -9,6 +9,8 @@ echo "========== 기본 초기화 시작 =========="
 # deploy 사용자 생성 및 SSH 키 등록
 if id "deploy" &>/dev/null; then
   echo "[INFO] deploy 사용자 이미 존재함"
+  echo "${deploy_ssh_private_key}" > /home/deploy/.ssh/gcp_deploy_key
+  chmod 600 /home/deploy/.ssh/gcp_deploy_key
 else
   echo "[INFO] deploy 사용자 생성 및 SSH 키 등록"
   useradd -m -s /bin/bash deploy
@@ -20,6 +22,8 @@ else
   chmod 600 /home/deploy/.ssh/gcp_deploy_key
   chown -R deploy:deploy /home/deploy/.ssh
 fi
+
+
 
 # deploy 사용자에 제한 sudo 권한 부여 (docker / openvpnas 제어용)
 if ! grep -q "deploy" /etc/sudoers; then

--- a/terraform/gcp/environments/prod/scripts/db-install.sh.tpl
+++ b/terraform/gcp/environments/prod/scripts/db-install.sh.tpl
@@ -26,19 +26,9 @@ fi
 
 echo "[INFO] 기본 초기화 완료"
 
-# ──────────────────────────────────────────────────────────────────
-# 1) 디스크 포맷 및 마운트
-#    - 디스크가 이미 포맷되어 있지 않다면 포맷
-#    - 마운트 지점: /mnt/mysql-data (필요 시 /var/lib/mysql 로 변경)
-# ──────────────────────────────────────────────────────────────────
 
 DEVICE="/dev/disk/by-id/google-mysql-data"
-MOUNT_POINT="/mnt/mysql-data"
-
-# 디스크가 ext4로 포맷되지 않았다면 포맷
-if ! blkid $${DEVICE} | grep -q ext4; then
-  mkfs.ext4 -F $${DEVICE}
-fi
+MOUNT_POINT="/mnt/tmp"
 
 # 마운트 디렉토리 생성
 mkdir -p $${MOUNT_POINT}
@@ -51,11 +41,8 @@ fi
 # 즉시 마운트
 mount $${MOUNT_POINT}
 
-# ──────────────────────────────────────────────────────────────────
-# 2) MySQL 설치 및 데이터 디렉토리 변경
-#    - Docker로 MySQL 컨테이너 실행 시, 데이터 볼륨을 /mnt/mysql-data에 연결
-#    (컨테이너 내부의 /var/lib/mysql ↔ 호스트의 /mnt/mysql-data)
-# ──────────────────────────────────────────────────────────────────
+# 4. mysql-data 서브디렉토리 생성
+mkdir -p $MOUNT_POINT/mysql-data
 
 
 # 로그 설정
@@ -76,7 +63,7 @@ docker run -d \
   -e MYSQL_DATABASE="${db_name}" \
   -e MYSQL_USER="${user_name}" \
   -e MYSQL_PASSWORD="${rootpasswd}" \
-  -v $${MOUNT_POINT}:/var/lib/mysql \
+  -v $${MOUNT_POINT}/mysql-data:/var/lib/mysql \
   -p 3306:3306 \
   mysql:8.0
 


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- DB 인스턴스에 백엔드 서버가 scp 접속 가능하도록 수정 
- mount point 수정

## 📋 상세 설명
- private subnet에 위치한 db 세팅의 유연성을 위해 백엔드 서버에서 basiton 서버처럼 서버 세팅할 수 있도록 설정하였습니다.
- mysql-data 디렉토리가 비어 있거나 db 세팅 이외의 폴더나 파일이 들어가면 오류가 나기 때문에 세팅과 볼륨을 분리하였습니다.
- 기존 `/mnt/mysql-data`  변경 후 ` /mnt/tmp/mysql-data`   /mnt/tmp에는 db 세팅 파일

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.