### PR TITLE
fix: 가동중인 ASG를 구분하는 코드 변경(active_deployment 값 -> instance_count의 max값)

### DIFF
--- a/terraform/gcp/environments/prod/output.tf
+++ b/terraform/gcp/environments/prod/output.tf
@@ -42,3 +42,12 @@ output "instance_groups" {
     frontend_green = module.frontend_asg_green.instance_group
   }
 }
+
+# ASG 인스턴스 크기 정보
+output "blue_instance_count" {
+  value = var.blue_instance_count
+}
+
+output "green_instance_count" {
+  value = var.green_instance_count
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
-  가동중인 ASG를 구분하는 코드 변경(active_deployment 값 -> instance_count의 max값)

## 📋 상세 설명
- active_deployment는 local 변수로만 사용되고, 리소스에 사용되지 않아, active_deployment값이 변해도 apply 시 변경하지 않는 문제가 있어서 로직을 변경
- 기존: active_deployment 값이 blue인지 green인지에 따라 target 그룹 지정
- 변경: blue_instance_count 또는 green_instance_count의 max 값이 0인 곳이 어디냐에 따라 target 그룹 지정

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.