### PR TITLE
fix: apply 시 traffic_weight_bluetraffic_weight_green 값의 변경을 적용하기 위해 리소스에 해당 값을 적용

### DIFF
--- a/terraform/gcp/environments/prod/main.tf
+++ b/terraform/gcp/environments/prod/main.tf
@@ -290,6 +290,7 @@ module "frontend_asg_green" {
 ############################################################
 module "backend_tg" {
   source       = "../../modules/target-group"
+  description  = "Traffic: blue ${var.traffic_weight_blue}% / green ${var.traffic_weight_green}%"
   name         = "${var.env}-backend-tg"
   health_check = local.hc_backend
   backends = [
@@ -310,11 +311,12 @@ module "backend_tg" {
 
 module "frontend_tg" {
   source       = "../../modules/target-group"
+  description  = "Traffic: blue ${var.traffic_weight_blue}% / green ${var.traffic_weight_green}%"
   name         = "${var.env}-frontend-tg"
   health_check = local.hc_frontend
   backends = [
     {
-    instance_group  = module.frontend_asg_blue.instance_group
+      instance_group  = module.frontend_asg_blue.instance_group
       weight          = local.normalized_blue_weight
       balancing_mode  = "UTILIZATION"
       capacity_scaler = 1.0

--- a/terraform/gcp/modules/target-group/main.tf
+++ b/terraform/gcp/modules/target-group/main.tf
@@ -2,6 +2,7 @@
 # Target Group(Backend Service) – GCP HTTP(S) LB 전용
 ############################################################
 resource "google_compute_backend_service" "this" {
+  description   = var.description
   name          = var.name
   protocol      = var.protocol          # HTTP | HTTPS | HTTP2 | GRPC
   port_name     = var.port_name         # "http" 기본

--- a/terraform/gcp/modules/target-group/variables.tf
+++ b/terraform/gcp/modules/target-group/variables.tf
@@ -11,6 +11,11 @@ variable "health_check" {
   type        = string
 }
 
+variable "description" {
+  description = "트래픽 변경 값 반영을 위한 설정"
+  type        = string
+}
+
 ##############################
 # backends 리스트
 ##############################
@@ -39,7 +44,7 @@ variable "port_name" {
 
 variable "timeout_sec" {
   type    = number
-  default = 30
+  default = 420
 }
 
 variable "connection_draining_sec" {


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- apply 시 traffic_weight_bluetraffic_weight_green 값의 변경을 적용하기 위해 리소스에 해당 값을 적용

## 📋 상세 설명
- `description` 속성을 추가해 traffic_weight_blue/traffic_weight_green 값이 반영되게 하여, apply 시 인식이 되게 변경
```
module "frontend_tg" {
  source       = "../../modules/target-group"
  ✅ description  = "Traffic: blue ${var.traffic_weight_blue}% / green ${var.traffic_weight_green}%"
  name         = "${var.env}-frontend-tg"
  health_check = local.hc_frontend
  backends = [
    {
      instance_group  = module.frontend_asg_blue.instance_group
      weight          = local.normalized_blue_weight
      balancing_mode  = "UTILIZATION"
      capacity_scaler = 1.0
    },
    {
      instance_group  = module.frontend_asg_green.instance_group
      weight          = local.normalized_green_weight
      balancing_mode  = "UTILIZATION"
      capacity_scaler = 1.0
    }
  ]
}
```

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.