### PR TITLE
fix: ASG 트래픽 받는 용량 조절을 weight -> capacity_scaler 속성으로 변경

### DIFF
--- a/terraform/gcp/environments/prod/main.tf
+++ b/terraform/gcp/environments/prod/main.tf
@@ -81,9 +81,9 @@ locals {
   external_lb_ip_self_link = data.terraform_remote_state.shared.outputs.prod_external_lb_ip_self_link
   
   # 트래픽 가중치 검증
-  total_weight            = var.traffic_weight_blue + var.traffic_weight_green
-  normalized_blue_weight  = local.total_weight > 0 ? (var.traffic_weight_blue * 100 / local.total_weight) : 0
-  normalized_green_weight = local.total_weight > 0 ? (var.traffic_weight_green * 100 / local.total_weight) : 0
+  # total_weight            = var.traffic_weight_blue + var.traffic_weight_green
+  # normalized_blue_weight  = local.total_weight > 0 ? (var.traffic_weight_blue * 100 / local.total_weight) : 0
+  # normalized_green_weight = local.total_weight > 0 ? (var.traffic_weight_green * 100 / local.total_weight) : 0
 
   ilb_proxy_subnet_self_link = data.terraform_remote_state.shared.outputs.ilb_proxy_subnet_self_link
   mysql_data_disk_self_link = data.terraform_remote_state.shared.outputs.prod_mysql_data_disk_self_link
@@ -296,15 +296,19 @@ module "backend_tg" {
   backends = [
     {
       instance_group  = module.backend_internal_asg_blue.instance_group
-      weight          = local.normalized_blue_weight
+      # weight          = local.normalized_blue_weight
+      weight          = var.traffic_weight_blue
       balancing_mode  = "UTILIZATION"
-      capacity_scaler = 1.0
+      # capacity_scaler = 1.0
+      capacity_scaler = var.traffic_weight_blue / 100.0
     },
     {
       instance_group  = module.backend_internal_asg_green.instance_group
-      weight          = local.normalized_green_weight
+      # weight          = local.normalized_green_weight
+      weight          = var.traffic_weight_green
       balancing_mode  = "UTILIZATION"
-      capacity_scaler = 1.0
+      # capacity_scaler = 1.0
+      capacity_scaler = var.traffic_weight_green / 100.0
     }
   ]
 }
@@ -317,15 +321,17 @@ module "frontend_tg" {
   backends = [
     {
       instance_group  = module.frontend_asg_blue.instance_group
-      weight          = local.normalized_blue_weight
+      # weight          = local.normalized_blue_weight
       balancing_mode  = "UTILIZATION"
-      capacity_scaler = 1.0
+      # capacity_scaler = 1.0
+      capacity_scaler = var.traffic_weight_blue / 100.0
     },
     {
       instance_group  = module.frontend_asg_green.instance_group
-      weight          = local.normalized_green_weight
+      # weight          = local.normalized_green_weight
       balancing_mode  = "UTILIZATION"
-      capacity_scaler = 1.0
+      # capacity_scaler = 1.0
+      capacity_scaler = var.traffic_weight_green / 100.0
     }
   ]
 }

--- a/terraform/gcp/environments/prod/main.tf
+++ b/terraform/gcp/environments/prod/main.tf
@@ -297,7 +297,7 @@ module "backend_tg" {
     {
       instance_group  = module.backend_internal_asg_blue.instance_group
       # weight          = local.normalized_blue_weight
-      weight          = var.traffic_weight_blue
+      # weight          = var.traffic_weight_blue
       balancing_mode  = "UTILIZATION"
       # capacity_scaler = 1.0
       capacity_scaler = var.traffic_weight_blue / 100.0
@@ -305,7 +305,7 @@ module "backend_tg" {
     {
       instance_group  = module.backend_internal_asg_green.instance_group
       # weight          = local.normalized_green_weight
-      weight          = var.traffic_weight_green
+      # weight          = var.traffic_weight_green
       balancing_mode  = "UTILIZATION"
       # capacity_scaler = 1.0
       capacity_scaler = var.traffic_weight_green / 100.0

--- a/terraform/gcp/environments/prod/output.tf
+++ b/terraform/gcp/environments/prod/output.tf
@@ -9,7 +9,7 @@ output "blue_deployment_status" {
   value = {
     # backend_instances  = var.blue_instance_count.desired
     # frontend_instances = var.blue_instance_count.desired
-    traffic_weight     = local.normalized_blue_weight
+    # traffic_weight     = local.normalized_blue_weight
     docker_images = {
       backend  = var.docker_image_backend_blue
       frontend = var.docker_image_front_blue
@@ -23,7 +23,7 @@ output "green_deployment_status" {
   value = {
     # backend_instances  = var.green_instance_count.desired
     # frontend_instances = var.green_instance_count.desired
-    traffic_weight     = local.normalized_green_weight
+    # traffic_weight     = local.normalized_green_weight
     docker_images = {
       backend  = var.docker_image_backend_green
       frontend = var.docker_image_front_green

--- a/terraform/gcp/environments/prod/variable.tf
+++ b/terraform/gcp/environments/prod/variable.tf
@@ -133,7 +133,7 @@ variable "active_deployment" {
 variable "traffic_weight_blue" {
   description = "Traffic weight for blue deployment (0-100)"
   type        = number
-  default     = 100
+  default     = 0
   
   validation {
     condition     = var.traffic_weight_blue >= 0 && var.traffic_weight_blue <= 100

--- a/terraform/gcp/modules/target-group/variables.tf
+++ b/terraform/gcp/modules/target-group/variables.tf
@@ -23,9 +23,9 @@ variable "backends" {
   description = "목표 백엔드 목록"
   type = list(object({
     instance_group   = string
-    weight           = optional(number, 100)        # 기본 100
     balancing_mode   = optional(string, "UTILIZATION") # CONNECTION | RATE | UTILIZATION
     capacity_scaler  = optional(number, 1.0)        # 0.0–1.0, 기본 1.0
+    # weight           = optional(number, 100)        # 기본 100
   }))
 }
 


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- ASG 트래픽 받는 용량 조절을 weight -> capacity_scaler 속성으로 변경

## 📋 상세 설명
- 부하분산의 backend 서비스에 weight 라는 속성이 없는 것으로 확인됨
- capacity_scaler 속성을 통해서 ASG의 backend에 꽂히는 트래픽 양을 조절할 수 있는 것으로 확인되어, 해당 속성에 traffic_weight_blue/traffic_weight_green을 연결

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.