### PR TITLE
refactor: nat 서브넷 zone 분리

### DIFF
--- a/terraform/gcp/environments/develop/main.tf
+++ b/terraform/gcp/environments/develop/main.tf
@@ -63,7 +63,7 @@ resource "google_compute_router_nat" "nat" {
 }
 
 locals {
-  nat_subnet_info = data.terraform_remote_state.shared.outputs.nat_subnet_info
+  nat_subnet_info = data.terraform_remote_state.shared.outputs.nat_a_subnet_info
 
   region           = var.region
   subnet_self_link = data.terraform_remote_state.shared.outputs.nat_a_subnet_self_link

--- a/terraform/gcp/environments/prod/main.tf
+++ b/terraform/gcp/environments/prod/main.tf
@@ -63,7 +63,7 @@ resource "google_compute_router_nat" "nat" {
 }
 
 locals {
-  nat_subnet_info = data.terraform_remote_state.shared.outputs.nat_subnet_info
+  nat_subnet_info = data.terraform_remote_state.shared.outputs.nat_b_subnet_info
   firewall_rules  = data.terraform_remote_state.shared.outputs.firewall_rules
 
   region           = var.region

--- a/terraform/gcp/environments/shared/output.tf
+++ b/terraform/gcp/environments/shared/output.tf
@@ -30,7 +30,7 @@ output "prod_private_subnet_self_link" {
    value = google_compute_subnetwork.shared_subnets["${var.vpc_name}-private-b"].self_link
 }
 
-output "nat_subnet_info" {
+output "nat_a_subnet_info" {
   value = {
     for s in google_compute_subnetwork.shared_subnets :
     s.name => {
@@ -38,7 +38,19 @@ output "nat_subnet_info" {
       self_link = s.self_link
       cidr      = s.ip_cidr_range
     }
-    if can(regex("-nat-", s.name))
+    if can(regex("-nat-a", s.name))
+  }
+}
+
+output "nat_b_subnet_info" {
+  value = {
+    for s in google_compute_subnetwork.shared_subnets :
+    s.name => {
+      name      = s.name
+      self_link = s.self_link
+      cidr      = s.ip_cidr_range
+    }
+    if can(regex("-nat-b", s.name))
   }
 }
 


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- nat 서브넷 zone 분리

## 📋 상세 설명

 nat 서브넷 zone 분리
```
output "nat_b_subnet_info" {
  value = {
    for s in google_compute_subnetwork.shared_subnets :
    s.name => {
      name      = s.name
      self_link = s.self_link
      cidr      = s.ip_cidr_range
    }
    if can(regex("-nat-b", s.name))
  }
}
```
## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.