### PR TITLE
fix: ASG 초기세팅 시간 속성으로 잘못된 속성을 사용하여 수정(cooldown_period 추가)

### DIFF
--- a/terraform/gcp/modules/mig-asg/main.tf
+++ b/terraform/gcp/modules/mig-asg/main.tf
@@ -40,7 +40,7 @@ resource "google_compute_region_instance_group_manager" "this" {
 
   auto_healing_policies {
     health_check      = var.health_check
-    initial_delay_sec = 420
+    initial_delay_sec = 300
   }
 }
 
@@ -53,5 +53,6 @@ resource "google_compute_region_autoscaler" "this" {
     min_replicas    = var.min
     max_replicas    = var.max
     cpu_utilization { target = var.cpu_target }
+    cooldown_period = 300
   }
 }

--- a/terraform/gcp/modules/target-group/variables.tf
+++ b/terraform/gcp/modules/target-group/variables.tf
@@ -44,7 +44,7 @@ variable "port_name" {
 
 variable "timeout_sec" {
   type    = number
-  default = 420
+  default = 30
 }
 
 variable "connection_draining_sec" {


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- ASG 초기세팅 시간 속성으로 잘못된 속성을 사용하여 수정(cooldown_period 추가)

## 📋 상세 설명
- `google_compute_region_instance_group_manager` 리소스의 `initial_delay_sec` 속성: 헬스체크 결과 무시 기간
-  `google_compute_region_autoscaler` 리소스의 `cooldown_period` 속성: ASG에서 인스턴스가 새로 올라왔을 때, 사용량 등에 대한 데이터를 수집하지 않도록 하는 기간

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.