### PR TITLE
refactor: 배포 테스트 가능한 도커 이미지 및 blue MIG를 기본으로 사용하게 변경(변수 default 값)

### DIFF
--- a/terraform/gcp/environments/prod/variable.tf
+++ b/terraform/gcp/environments/prod/variable.tf
@@ -89,13 +89,13 @@ variable "domain_frontend" {
 variable "docker_image_backend_blue" {
   description = "백엔드 Blue 컨테이너 이미지 (예: gcr.io/proj/backend:blue)"
   type        = string
-  default = "gcr.io/proj/backend:blue"
+  default = "969400486509.dkr.ecr.ap-northeast-2.amazonaws.com/tuning-springboot:develop-latest"
 }
 
 variable "docker_image_backend_green" {
   description = "백엔드 Green 컨테이너 이미지 (예: gcr.io/proj/backend:green)"
   type        = string
-  default = "gcr.io/proj/backend:green"
+  default = "969400486509.dkr.ecr.ap-northeast-2.amazonaws.com/tuning-nextjs:develop-latest"
 }
 
 variable "docker_image_front_blue" {
@@ -133,7 +133,7 @@ variable "active_deployment" {
 variable "traffic_weight_blue" {
   description = "Traffic weight for blue deployment (0-100)"
   type        = number
-  default     = 0
+  default     = 100
   
   validation {
     condition     = var.traffic_weight_blue >= 0 && var.traffic_weight_blue <= 100
@@ -144,7 +144,7 @@ variable "traffic_weight_blue" {
 variable "traffic_weight_green" {
   description = "Traffic weight for green deployment (0-100)"
   type        = number
-  default     = 10
+  default     = 0
   
   validation {
     condition     = var.traffic_weight_green >= 0 && var.traffic_weight_green <= 100
@@ -162,8 +162,8 @@ variable "blue_instance_count" {
   })
   default = {
     # desired = 1
-    min     = 0
-    max     = 0
+    min     = 1
+    max     = 2
   }
 }
 

--- a/terraform/gcp/environments/prod/variable.tf
+++ b/terraform/gcp/environments/prod/variable.tf
@@ -95,19 +95,19 @@ variable "docker_image_backend_blue" {
 variable "docker_image_backend_green" {
   description = "백엔드 Green 컨테이너 이미지 (예: gcr.io/proj/backend:green)"
   type        = string
-  default = "969400486509.dkr.ecr.ap-northeast-2.amazonaws.com/tuning-nextjs:develop-latest"
+  default = "969400486509.dkr.ecr.ap-northeast-2.amazonaws.com/tuning-springboot:develop-latest"
 }
 
 variable "docker_image_front_blue" {
   description = "프론트엔드 Blue 컨테이너 이미지 (예: gcr.io/proj/frontend:blue)"
   type        = string
-  default = "gcr.io/proj/frontend:blue"
+  default = "969400486509.dkr.ecr.ap-northeast-2.amazonaws.com/tuning-nextjs:develop-latest"
 }
 
 variable "docker_image_front_green" {
   description = "프론트엔드 Green 컨테이너 이미지 (예: gcr.io/proj/frontend:green)"
   type        = string
-  default = "gcr.io/proj/frontend:green"
+  default = "969400486509.dkr.ecr.ap-northeast-2.amazonaws.com/tuning-nextjs:develop-latest"
 }
 
 variable "proxy_subnet_cidr" {


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- 배포 테스트 가능한 도커 이미지 및 blue MIG를 기본으로 사용하게 변경(변수 default 값)

## 📋 상세 설명
- 배포 테스트 가능한 도커 이미지로 back/front default 이미지를 변경
- 초기 apply 시 blue MIG가 동작되도록 변경

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.