### PR TITLE
refactor: Target MIG에 배포 시 트래픽량 수정(100 -> 0)

### DIFF
--- a/frontend/workflows/docker-cicd-frontend.yml
+++ b/frontend/workflows/docker-cicd-frontend.yml
@@ -241,7 +241,7 @@ jobs:
           TARGET=${{ steps.color.outputs.target }}
           echo "{" > 01-deployment.auto.tfvars.json
           echo "  \"traffic_weight_${ACTIVE}\": 100," >> 01-deployment.auto.tfvars.json
-          echo "  \"traffic_weight_${TARGET}\": 100," >> 01-deployment.auto.tfvars.json
+          echo "  \"traffic_weight_${TARGET}\": 0," >> 01-deployment.auto.tfvars.json
           echo "  \"docker_image_front_${TARGET}\": \"${{ env.IMAGE }}\"," >> 01-deployment.auto.tfvars.json
           echo "  \"blue_instance_count\": {\"min\": 1, \"max\": 2}," >> 01-deployment.auto.tfvars.json
           echo "  \"green_instance_count\": {\"min\": 1, \"max\": 2}" >> 01-deployment.auto.tfvars.json


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- Target MIG에 배포 시 트래픽량 수정(100 -> 0)

## 📋 상세 설명
- Target MIG에 새로운 버전을 업데이트를 올렸을 때, 아직 트래픽이 꽂히면 안됨
- 따라서 기존 트래픽량 100에서 0으로 조정

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.