### PR TITLE
refactor: 블루-그린 배포 시, front/back 공통으로 사용되는 변수 분리

### DIFF
--- a/terraform/gcp/environments/prod/output.tf
+++ b/terraform/gcp/environments/prod/output.tf
@@ -44,18 +44,33 @@ output "instance_groups" {
 }
 
 # ASG 인스턴스 크기 정보
-output "blue_instance_count" {
-  value = var.blue_instance_count
+output "blue_instance_count_frontend" {
+  value = var.blue_instance_count_frontend
+}
+output "blue_instance_count_backend" {
+  value = var.blue_instance_count_backend
 }
 
-output "green_instance_count" {
-  value = var.green_instance_count
+output "green_instance_count_frontend" {
+  value = var.green_instance_count_frontend
 }
 
-output "traffic_weight_blue" {
-  value = var.traffic_weight_blue
+output "green_instance_count_backend" {
+  value = var.green_instance_count_backend
 }
 
-output "traffic_weight_green" {
-  value = var.traffic_weight_green
+output "traffic_weight_blue_frontend" {
+  value = var.traffic_weight_blue_frontend
+}
+
+output "traffic_weight_blue_backend" {
+  value = var.traffic_weight_blue_backend
+}
+
+output "traffic_weight_green_frontend" {
+  value = var.traffic_weight_green_frontend
+}
+
+output "traffic_weight_green_backend" {
+  value = var.traffic_weight_green_backend
 }

--- a/terraform/gcp/environments/prod/variable.tf
+++ b/terraform/gcp/environments/prod/variable.tf
@@ -130,30 +130,52 @@ variable "active_deployment" {
   }
 }
 
-variable "traffic_weight_blue" {
+variable "traffic_weight_blue_frontend" {
   description = "Traffic weight for blue deployment (0-100)"
   type        = number
   default     = 100
   
   validation {
-    condition     = var.traffic_weight_blue >= 0 && var.traffic_weight_blue <= 100
+    condition     = var.traffic_weight_blue_frontend >= 0 && var.traffic_weight_blue_frontend <= 100
     error_message = "Traffic weight must be between 0 and 100."
   }
 }
 
-variable "traffic_weight_green" {
+variable "traffic_weight_blue_backend" {
+  description = "Traffic weight for blue deployment (0-100)"
+  type        = number
+  default     = 100
+  
+  validation {
+    condition     = var.traffic_weight_blue_backend >= 0 && var.traffic_weight_blue_backend <= 100
+    error_message = "Traffic weight must be between 0 and 100."
+  }
+}
+
+variable "traffic_weight_green_frontend" {
   description = "Traffic weight for green deployment (0-100)"
   type        = number
   default     = 0
   
   validation {
-    condition     = var.traffic_weight_green >= 0 && var.traffic_weight_green <= 100
+    condition     = var.traffic_weight_green_frontend >= 0 && var.traffic_weight_green_frontend <= 100
+    error_message = "Traffic weight must be between 0 and 100."
+  }
+}
+
+variable "traffic_weight_green_backend" {
+  description = "Traffic weight for green deployment (0-100)"
+  type        = number
+  default     = 0
+  
+  validation {
+    condition     = var.traffic_weight_green_backend >= 0 && var.traffic_weight_green_backend <= 100
     error_message = "Traffic weight must be between 0 and 100."
   }
 }
 
 # ASG 크기 제어
-variable "blue_instance_count" {
+variable "blue_instance_count_frontend" {
   description = "Number of instances for blue deployment"
   type = object({
     # desired = number
@@ -167,7 +189,21 @@ variable "blue_instance_count" {
   }
 }
 
-variable "green_instance_count" {
+variable "blue_instance_count_backend" {
+  description = "Number of instances for blue deployment"
+  type = object({
+    # desired = number
+    min     = number
+    max     = number
+  })
+  default = {
+    # desired = 1
+    min     = 1
+    max     = 2
+  }
+}
+
+variable "green_instance_count_frontend" {
   description = "Number of instances for green deployment"
   type = object({
     # desired = number
@@ -181,6 +217,19 @@ variable "green_instance_count" {
   }
 }
 
+variable "green_instance_count_backend" {
+  description = "Number of instances for green deployment"
+  type = object({
+    # desired = number
+    min     = number
+    max     = number
+  })
+  default = {
+    # desired = 0
+    min     = 0
+    max     = 0
+  }
+}
 
 variable "mysql_root_password" {
   description = "MySQL root 사용자 비밀번호"


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- 블루-그린 배포 시, front/back 공통으로 사용되는 변수 분리

## 📋 상세 설명
- 블루-그린 배포 시 front/back 공통으로 사용되는 변수가 하나였는데, frontend/backend 용으로 분리

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.