### PR TITLE
hotfix: 도커 배포 시 ecr 만료 되면 배포가 안되는 이슈 해결

### DIFF
--- a/.github/workflows/deploy-ai.yml
+++ b/.github/workflows/deploy-ai.yml
@@ -92,19 +92,43 @@ jobs:
             echo "✅ 이미 실행 중 - 대기 생략"
           fi
 
+       # 2. AWS 인증
+      - name: Configure AWS credentials
+        if: env.DEPLOY_TYPE == 'docker'
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      # 3. ECR 로그인
+      - name: Login to Amazon ECR
+        if: env.DEPLOY_TYPE == 'docker'
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Set registry
+        if: env.DEPLOY_TYPE == 'docker'
+        run: echo "ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV
+
       - name: Deploy via SSH
         uses: appleboy/ssh-action@master
         with:
           host: ${{ env.HOST }}
           username: ${{ secrets.SSH_USERNAME }}
           key: ${{ secrets.SSH_PRIVATE_KEY }}
+          envs: AWS_REGION,ECR_REGISTRY
         
           script: |
+            
             if [[ "${{ env.DEPLOY_TYPE }}" == "docker" ]]; then
+    
               echo "🚀 Docker 배포 시작..."
               cd /home/deploy
               pm2 stop ecosystem.config.js || true
+              aws ecr get-login-password --region ${{ env.AWS_REGION }} | docker login --username AWS --password-stdin ${{ env.ECR_REGISTRY }}
               sleep 5
+
               docker compose --env-file .env up -d
             else
               echo "🚀 PM2 배포 시작..."


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- deploy-ai 에 ecr 로그인 로직 추가
## 📋 상세 설명
- ecr 토큰은 12시간이 지나면 만료가 되기 때문에 ECR을 그 때 마다 로그인을 해주어야 한다.
- `aws ecr get-login-password --region ${{ env.AWS_REGION }} | docker login --username AWS --password-stdin ${{ env.ECR_REGISTRY }}`
- 도커로 배포하는 경우에만 로그인

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.