### PR TITLE
feat: DB 디스크 스냅샷 일정 추가

### DIFF
--- a/terraform/gcp/modules/target-group/variables.tf
+++ b/terraform/gcp/modules/target-group/variables.tf
@@ -49,7 +49,7 @@ variable "timeout_sec" {
 
 variable "connection_draining_sec" {
   type    = number
-  default = 0
+  default = 300
 }
 
 variable "session_affinity" {


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- DB 디스크 스냅샷 일정 추가

## 📋 상세 설명
- 스냅샷 정책(snapshot_policy) 추가
- \+ 디스크 이름에 suffix 추가(-dev, -prod)

**백업 정책**

> 대상: DB VM에 연결된 디스크에 대한 스냅샷
> 백업 주기: 매일 04시, 하루 3회, 8시간 간격 자동 실행
> 백업 방식: GCP의 증분 스냅샷 기능 활용
> 보존 기간: 30일 유지 및 자동 삭제

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.