### PR TITLE
Fix: lb redirection

### DIFF
--- a/backend/workflows/docker-cicd-backend.yml
+++ b/backend/workflows/docker-cicd-backend.yml
@@ -19,6 +19,7 @@ on:
         options:
           - local
           - dev
+          - app
 
 jobs:
   backend-ci:
@@ -284,6 +285,8 @@ jobs:
             REDIRECT_URL="${{ secrets.REDIRECT_URL_LOCAL }}"
           elif [[ "${{ github.event.inputs.redirect_url }}" == "dev" ]]; then
             REDIRECT_URL="${{ secrets.REDIRECT_URL_DEV }}"
+          elif [[ "${{ github.event.inputs.redirect_url }}" == "app" ]]; then
+            REDIRECT_URL="${{ secrets.REDIRECT_URL_APP }}"
           else
             echo "[ERROR]Redirect URL을 선택해주세요."
             exit 1

--- a/helm/nextjs-fe/values-dev.yaml
+++ b/helm/nextjs-fe/values-dev.yaml
@@ -4,3 +4,5 @@ image:
 
 ingress:
   host: dev-alb-external-2a-1092857731.ap-northeast-2.elb.amazonaws.com
+  
+  namespace: hertz-tuning-dev

--- a/helm/nextjs-fe/values-prod.yaml
+++ b/helm/nextjs-fe/values-prod.yaml
@@ -4,3 +4,5 @@ image:
 
 ingress:
   host: www.my-production-domain.com
+
+namespace: hertz-tuning-prod


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- external-https-lb 모듈을 수정하여 HTTP에서 HTTPS로의 리디렉션을 구현

## 📋 상세 설명
- 기존 google_compute_url_map에 default_url_redirect 설정을 추가하여 리디렉션 로직을 처리합니다. 이 설정은 쿼리 파라미터를 보존하고 301 (MOVED_PERMANENTLY_DEFAULT) 응답 코드를 사용합니다.
- 수정된 URL 맵을 사용하는 새로운 google_compute_target_http_proxy 리소스를 생성했습니다.
- HTTPS 전달 규칙과 동일한 IP 주소를 사용하고 새로운 HTTP 프록시를 대상으로 하는 포트 80 google_compute_global_forwarding_rule 리소스를 새로 생성했습니다.

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.