### PR TITLE
Feat: k8s backend

### DIFF
--- a/argoCD/templates/clustersecretstore.yaml
+++ b/argoCD/templates/clustersecretstore.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.global.createClusterSecretStore }}
+apiVersion: external-secrets.io/v1beta1
+kind: ClusterSecretStore
+metadata:
+  name: aws-ssm-store
+spec:
+  provider:
+    aws:
+      service: ParameterStore
+      region: ap-northeast-2
+      auth:
+        secretRef:
+          accessKeyID:
+            name: {{ .Values.global.awsSecretName }}
+            key: access-key-id
+            namespace: {{ .Values.global.secretNamespace }}
+          secretAccessKey:
+            name: {{ .Values.global.awsSecretName }}
+            key: secret-access-key
+            namespace: {{ .Values.global.secretNamespace }}
+{{- end }}

--- a/helm/README.md
+++ b/helm/README.md
@@ -47,3 +47,12 @@ helm upgrade --install nextjs-fe helm/nextjs-fe \
   -f helm/nextjs-fe/values.yaml \
   -f helm/nextjs-fe/values-prod.yaml \
   --set imagePullSecret=ecr-regcred
+
+
+  # 개발 환경
+helm upgrade --install springboot-be helm/springboot-be \
+  -f helm/springboot-be/values.yaml \
+  -f helm/springboot-be/values-dev.yaml \
+  --namespace hertz-tuning-dev \
+  --create-namespace \
+  --set imagePullSecret=ecr-regcred

--- a/helm/springboot-be/Chart.yaml
+++ b/helm/springboot-be/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: springboot-be
+description: A Helm chart for deploying Spring Boot Backend with External Secrets integration
+type: application
+version: 0.1.0              # Helm chart 버전
+appVersion: "1.0.0"         # 실제 앱(스프링 부트)의 버전
+maintainers:
+  - name: Lee Yeonghak
+    email: your.email@example.com

--- a/helm/springboot-be/templates/deployment.yaml
+++ b/helm/springboot-be/templates/deployment.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "springboot-be.fullname" . }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "springboot-be.fullname" . }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "springboot-be.fullname" . }}
+    spec:
+      imagePullSecrets:
+        - name: {{ .Values.imagePullSecret }}
+      containers:
+        - name: springboot
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
+          args: ["--spring.mvc.async.request-timeout=-1"]
+          envFrom:
+            - secretRef:
+                name: {{ include "springboot-be.fullname" . }}-secrets
+          ports:
+            - containerPort: 8080
+          readinessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /actuator/health
+              port: 8080
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: {{ .Values.resources.requests.cpu }}
+              memory: {{ .Values.resources.requests.memory }}
+            limits:
+              cpu: {{ .Values.resources.limits.cpu }}
+              memory: {{ .Values.resources.limits.memory }}

--- a/helm/springboot-be/templates/externalsecret.yaml
+++ b/helm/springboot-be/templates/externalsecret.yaml
@@ -1,0 +1,16 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: {{ include "springboot-be.fullname" . }}-secrets
+  namespace: {{ .Release.Namespace }}
+spec:
+  refreshInterval: 3m
+  secretStoreRef:
+    name: aws-ssm-store
+    kind: ClusterSecretStore
+  target:
+    name: {{ include "springboot-be.fullname" . }}-secrets
+    creationPolicy: Owner
+  dataFrom:
+    - extract:
+        key: {{ .Values.secret.path }}

--- a/helm/springboot-be/templates/service.yaml
+++ b/helm/springboot-be/templates/service.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "springboot-be.fullname" . }}-svc
+spec:
+  type: ClusterIP
+  selector:
+    app: {{ include "springboot-be.fullname" . }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: 8080

--- a/helm/springboot-be/values.yaml
+++ b/helm/springboot-be/values.yaml
@@ -1,0 +1,23 @@
+replicaCount: 1
+
+image:
+  repository: 969400486509.dkr.ecr.ap-northeast-2.amazonaws.com/tuning-springboot
+  tag: develop-latest
+
+imagePullSecret: ecr-regcred
+
+resources:
+  requests:
+    cpu: 500m
+    memory: 512Mi
+  limits:
+    cpu: 1
+    memory: 1Gi
+
+secret:
+  path: /global/springboot/dev/
+
+global:
+  createClusterSecretStore: false
+  awsSecretName: aws-credentials
+  secretNamespace: external-secrets

--- a/terraform/gcp/environments/develop/scripts/backend-install.sh.tpl
+++ b/terraform/gcp/environments/develop/scripts/backend-install.sh.tpl
@@ -92,8 +92,6 @@ echo "$PARAM_JSON" | jq -r '.Parameters[] | "\(.Name | ltrimstr("'"$SSM_PATH"'")
 
 
 echo "✅ SSM 파라미터를 $ENV_FILE 파일로 저장 완료"
-LOCAL_DB_HOST="${db_host}"
-echo "DB_HOST=$LOCAL_DB_HOST" >> "$ENV_FILE"
 
 # 이미지 변수 설정 (ECR 이미지)
 export IMAGE="${docker_image}"

--- a/terraform/gcp/environments/prod/scripts/backend-install.sh.tpl
+++ b/terraform/gcp/environments/prod/scripts/backend-install.sh.tpl
@@ -92,8 +92,7 @@ echo "$PARAM_JSON" | jq -r '.Parameters[] | "\(.Name | ltrimstr("'"$SSM_PATH"'")
 
 
 echo "✅ SSM 파라미터를 $ENV_FILE 파일로 저장 완료"
-LOCAL_DB_HOST="${db_host}"
-echo "DB_HOST=$LOCAL_DB_HOST" >> "$ENV_FILE"
+
 
 # 이미지 변수 설정 (ECR 이미지)
 export IMAGE="${docker_image}"


### PR DESCRIPTION
## 🔗 관련 이슈
- (https://github.com/100-hours-a-week/2-hertz-wiki/issues/344)

## ✏️ 변경 사항
	•	springboot-be용 Helm 차트 디렉토리(helm/springboot-be) 신규 추가
	•	Spring Boot Deployment, Service, ExternalSecret 템플릿 작성
	•	ExternalSecret을 통한 SSM 파라미터 연동 환경 구성
	•	values-dev.yaml 및 values-prod.yaml 환경 분리 설정 추가
	•	공통 ClusterSecretStore는 외부에서 관리하도록 분리 (Helm 포함 X)

## 📋 상세 설명
	•	Spring Boot 백엔드를 Helm으로 배포 가능하도록 템플릿을 구성했습니다.
	•	ExternalSecret을 이용하여 SSM 파라미터(/global/springboot/dev/)를 자동 주입받아 환경변수를 설정합니다.
	•	envFrom.secretRef를 통해 Pod에 환경변수가 삽입되며, readiness 및 liveness probe가 /api/ping으로 설정되어 있습니다.
	•	Namespace는 hertz-tuning-dev로 기본 설정되어 있으며, 필요시 values.yaml에서 오버라이드할 수 있습니다.
	•	imagePullSecrets, resources, replica 수, readiness/liveness probe 등도 values에서 설정 가능하도록 처리했습니다.

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.