### PR TITLE
refactor: websocket  타겟 그룹 추가 , 로드 밸런서 수정

### DIFF
--- a/terraform/gcp/environments/develop/main.tf
+++ b/terraform/gcp/environments/develop/main.tf
@@ -240,6 +240,8 @@ module "backend_tg" {
   affinity_cookie_ttl_sec = 0
 }
 
+
+
 module "frontend_tg" {
   source       = "../../modules/target-group"
   name         = "${var.env}-fe-tg"
@@ -254,15 +256,17 @@ module "frontend_tg" {
     }
   ]
 }
-/*
+
 module "websocket_tg" {
   source       = "../../modules/target-group"
   name         = "${var.env}-ws-tg"
   description  = "WebSocket Target Group"
-  health_check = local.hc_websocket
+  
+  health_check = local.hc_backend
+  port_name = "ws"
   backends = [
     {
-      instance_group  = module.websocket_ig.instance_group
+      instance_group  = module.module.backend_ig.instance_group
       #weight          = 100
       balancing_mode  = "UTILIZATION"
       capacity_scaler = 1.0
@@ -272,7 +276,7 @@ module "websocket_tg" {
   session_affinity        = "GENERATED_COOKIE"
   affinity_cookie_ttl_sec = 0
   
-}*/
+}
 
 ############################################################
 # 외부 HTTPS LB + URL Map (프론트엔드 기본, /api/* 백엔드)
@@ -285,7 +289,7 @@ module "external_lb" {
   domains          = [var.domain_frontend]
   backend_service  = module.backend_tg.backend_service_self_link
   frontend_service = module.frontend_tg.backend_service_self_link
-  //websocket_service = module.websocket_tg.backend_service_self_link
+  websocket_service = module.websocket_tg.backend_service_self_link
   lb_ip = {
     address     = local.external_lb_ip
     self_link   = local.external_lb_ip_self_link

--- a/terraform/gcp/modules/external-https-lb/main.tf
+++ b/terraform/gcp/modules/external-https-lb/main.tf
@@ -25,9 +25,15 @@ resource "google_compute_url_map" "this" {
     name            = "main-matcher"
     default_service = var.frontend_service  # "/" 이하 기본은 프론트엔드 서비스로
 
-    path_rule {
+     path_rule {
       paths   = ["/ws/*"]
-      service = var.backend_service  # WebSocket 서비스
+      route_action {
+        url_rewrite {
+          # /ws/foo/bar → /socket.io/foo/bar
+          path_prefix_rewrite = "/socket.io"
+        }
+      }
+      service = var.websocket_service
     }
     # --- Spring Boot API(기존) ---
     path_rule {

--- a/terraform/gcp/modules/external-https-lb/variables.tf
+++ b/terraform/gcp/modules/external-https-lb/variables.tf
@@ -19,10 +19,10 @@ variable "frontend_service" {
   type        = string
 }
 
-/*variable "websocket_service" {
+variable "websocket_service" {
   description = "WebSocket 전용 BackendService self_link"
   type        = string
-}*/
+}
 
 variable "lb_ip" {
   description = "External Load Balancer의 Global IP 주소 self_link"

--- a/terraform/gcp/modules/mig-asg/main.tf
+++ b/terraform/gcp/modules/mig-asg/main.tf
@@ -39,6 +39,11 @@ resource "google_compute_region_instance_group_manager" "this" {
     port = var.port_http
   }
 
+  named_port {
+    name = "ws"
+    port = var.port_ws
+  }
+
 
   version {
     instance_template  = google_compute_instance_template.this.id

--- a/terraform/gcp/modules/mig-asg/variables.tf
+++ b/terraform/gcp/modules/mig-asg/variables.tf
@@ -96,3 +96,9 @@ variable "is_dev_env" {
   type        = bool
   default     = false
 }
+
+variable "port_ws" {
+  description = "Port for WebSocket connections"
+  type        = number
+  default     = 9092
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- 웹소켓 타겟 그룹 추가
- lb에 웹소켓 backend_service 연결

## 📋 상세 설명
```
module "websocket_tg" {
  source       = "../../modules/target-group"
  name         = "${var.env}-ws-tg"
  description  = "WebSocket Target Group"
  
  health_check = local.hc_backend
  port_name = "ws"
  backends = [
    {
      instance_group  = module.module.backend_ig.instance_group
      #weight          = 100
      balancing_mode  = "UTILIZATION"
      capacity_scaler = 1.0
    }
...
}


```
```
 path_rule {
      paths   = ["/ws/*"]
      route_action {
        url_rewrite {
          # /ws/foo/bar → /socket.io/foo/bar
          path_prefix_rewrite = "/socket.io"
        }
      }
      service = var.websocket_service
    }
```


## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.