### PR TITLE
hotfix: kafka는 aws로 처리

### DIFF
--- a/terraform/gcp/environments/develop/main.tf
+++ b/terraform/gcp/environments/develop/main.tf
@@ -358,7 +358,7 @@ resource "google_compute_instance" "mysql_vm" {
   }
 }
 
-
+/*
 resource "google_compute_address" "kafka_internal_ip" {
   name         = "${var.env}-kafka-internal-ip"
   address_type = "INTERNAL"
@@ -397,7 +397,7 @@ resource "google_compute_instance" "kafka_vm" {
   metadata = {
     ssh-keys = "deploy:${var.deploy_ssh_public_key}"
   }
-}
+}*/
 
 
 


### PR DESCRIPTION
hotfix: kafka는 SSD, CPU 제한으로 gcp 환경에서 구축하는 것이 어렵다고 판단 -> AWS로 전환