### PR TITLE
fix: path_prefix_rewrite 변경

### DIFF
--- a/terraform/gcp/modules/external-https-lb/main.tf
+++ b/terraform/gcp/modules/external-https-lb/main.tf
@@ -33,7 +33,7 @@ resource "google_compute_url_map" "this" {
     ]
       route_action {
         url_rewrite {
-          path_prefix_rewrite = "/socket.io"
+          path_prefix_rewrite = "/socket.io/"
         }
       }
       service = var.websocket_service


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- path_prefix_rewrite 변경 `path_prefix_rewrite = "/socket.io"` -> `path_prefix_rewrite = "/socket.io/"`

## 📋 상세 설명
- 입력: wss://stage.hertz-tuning.com/ws/?EIO=3&transport=websocket
- 매칭: /ws/ 경로가 ["/ws", "/ws/", "/ws/*"]와 매칭
- 재작성: /ws/ → /socket.io/
- 최종 전달: ws://localhost:9100/socket.io/?EIO=3&transport=websocket

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.