### PR TITLE
feat: 로드밸런서->웹소켓 방화벽 추가

### DIFF
--- a/terraform/gcp/environments/prod/main.tf
+++ b/terraform/gcp/environments/prod/main.tf
@@ -624,6 +624,20 @@ locals {
       target_tags  = ["redis"]
       protocol     = "tcp"
       ports        = ["6379"]
+    },
+
+    {
+      name          = "${var.vpc_name}-fw-to-websocket"
+      direction     = "INGRESS"
+      priority      = 1000
+      description   = "Allow GCP Health Checks (130.211.0.0/22, 35.191.0.0/16) to websocket on TCP:9100"
+      source_ranges = [
+        "130.211.0.0/22",
+        "35.191.0.0/16",
+      ]
+      target_tags   = ["websocket","backend"]
+      protocol      = "tcp"
+      ports         = ["9100"]
     }
    
    


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- feat: 로드밸런서->웹소켓 방화벽 추가 9100
 ```
 {
      name          = "${var.vpc_name}-fw-to-websocket"
      direction     = "INGRESS"
      priority      = 1000
      description   = "Allow GCP Health Checks (130.211.0.0/22, 35.191.0.0/16) to websocket on TCP:9100"
      source_ranges = [
        "130.211.0.0/22",
        "35.191.0.0/16",
      ]
      target_tags   = ["websocket","backend"]
      protocol      = "tcp"
      ports         = ["9100"]
    }
```

## 📋 상세 설명
- 로드밸런서를 통해 웹소켓 서버로 접속이 될 수 있도록 방화벽 추가

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.