### PR TITLE
fix: kafka 방화벽 추가

### DIFF
--- a/terraform/gcp/environments/develop/main.tf
+++ b/terraform/gcp/environments/develop/main.tf
@@ -516,7 +516,18 @@ locals {
       target_tags   = ["websocket","backend"]
       protocol      = "tcp"
       ports         = ["9100"]
-    }
+    },
+    {
+      name        = "${var.env}-fw-kafka-to-kafka"
+      direction   = "INGRESS"
+      priority    = 1000
+      description = "Allow Kafka access from  on ports 9092-9094"
+      # 허용할 소스 IP (싱글 IP라면 /32)
+      source_ranges = var.kafka_source_ranges
+      # 태그가 kafka 인 인스턴스에만 적용
+      target_tags   = ["backend","frontend"]
+      ports    = ["9092-9094"]
+    },
    
   ]
 

--- a/terraform/gcp/environments/develop/variable.tf
+++ b/terraform/gcp/environments/develop/variable.tf
@@ -245,3 +245,9 @@ variable "kafka_internal_ip" {
   type        = string
   default     = ""
 }
+
+variable "kafka_source_ranges" {
+  description = "Kafka 브로커로의 인바운드 트래픽을 허용할 source CIDR 리스트"
+  type        = list(string)
+  default     = [""]
+}

--- a/terraform/gcp/environments/prod/main.tf
+++ b/terraform/gcp/environments/prod/main.tf
@@ -613,8 +613,19 @@ locals {
       target_tags  = ["kafka"]
       protocol     = "tcp"
       ports        = ["9092"]
-    }
-    ,
+    },
+
+{
+      name        = "${var.env}-fw-kafka-to-kafka"
+      direction   = "INGRESS"
+      priority    = 1000
+      description = "Allow Kafka access from  on ports 9092-9094"
+      # 허용할 소스 IP (싱글 IP라면 /32)
+      source_ranges = var.kafka_source_ranges
+      # 태그가 kafka 인 인스턴스에만 적용
+      target_tags   = ["backend","frontend"]
+      ports    = ["9092-9094"]
+    },
     {
       name         = "${var.env}-fw-kafka-to-redis"
       direction    = "INGRESS"

--- a/terraform/gcp/environments/prod/variable.tf
+++ b/terraform/gcp/environments/prod/variable.tf
@@ -266,3 +266,8 @@ variable "docker_image_websocket" {
   default     = "969400486509.dkr.ecr.ap-northeast-2.amazonaws.com/tuning-websocket:main-latest"
   
 }
+variable "kafka_source_ranges" {
+  description = "Kafka 브로커에 접근할 수 있는 IP 주소 범위 (예:"
+  type        = list(string)
+  default     = [""]
+}


### PR DESCRIPTION
## 🔗 관련 이슈
- (https://github.com/100-hours-a-week/2-hertz-wiki/issues/396)

## ✏️ 변경 사항
- kafka -> be,fe 방화벽 추가

## 📋 상세 설명
```
{
      name        = "${var.env}-fw-kafka-to-kafka"
      direction   = "INGRESS"
      priority    = 1000
      description = "Allow Kafka access from  on ports 9092-9094"
      # 허용할 소스 IP (싱글 IP라면 /32)
      source_ranges = var.kafka_source_ranges
      # 태그가 kafka 인 인스턴스에만 적용
      target_tags   = ["backend","frontend"]
      ports    = ["9092-9094"]
    }
```

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.