### PR TITLE
fix: /socket.io로 보내도 통신이 되도록 수정

### DIFF
--- a/terraform/gcp/modules/external-https-lb/main.tf
+++ b/terraform/gcp/modules/external-https-lb/main.tf
@@ -29,7 +29,10 @@ resource "google_compute_url_map" "this" {
        paths = [
       "/ws",   # wss://…/ws
       "/ws/",  # wss://…/ws/
-      "/ws/*"  # wss://…/ws/anything
+      "/ws/*",  # wss://…/ws/anything
+      "/socket.io",   # wss://…/socket.io
+      "/socket.io/",  # wss://…/socket.io/
+      "/socket.io/*"  # wss://…/socket.io/anything
     ]
       route_action {
         url_rewrite {


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
```
path_rule {
       paths = [
      "/ws",   # wss://…/ws
      "/ws/",  # wss://…/ws/
      "/ws/*",  # wss://…/ws/anything
      "/socket.io",   # wss://…/socket.io
      "/socket.io/",  # wss://…/socket.io/
      "/socket.io/*"  # wss://…/socket.io/anything
    ]
```
## 📋 상세 설명
- k8s alb controller에서 rewrite를 사용하지 않아 /socket.io로 분기 하기로 결정

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.