### PR TITLE
Origin/feature/k8s kafka

### DIFF
--- a/k8s/kafka/kafka-deployment.yaml
+++ b/k8s/kafka/kafka-deployment.yaml
@@ -82,6 +82,15 @@ spec:
                   operator: In
                   values: ["kafka1", "kafka2", "kafka3"]
               topologyKey: kubernetes.io/hostname
+      initContainers:
+      - name: fix-permissions
+        image: busybox
+        command: ['sh', '-c', 'rm -rf /var/lib/kafka/data/lost+found && chown -R 1000:1000 /var/lib/kafka/data']
+        volumeMounts:
+        - name: kafka-data
+          mountPath: /var/lib/kafka/data
+        securityContext:
+          runAsUser: 0
       containers:
       - name: kafka1
         image: confluentinc/cp-kafka:7.6.0
@@ -98,6 +107,9 @@ spec:
           value: "INTERNAL://kafka1:29092,EXTERNAL://kafka1:9092"
         - name: KAFKA_LISTENERS
           value: "INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092"
+        volumeMounts:
+        - name: kafka-data
+          mountPath: /var/lib/kafka/data
         resources:
           requests:
             cpu: 500m
@@ -105,6 +117,10 @@ spec:
           limits:
             cpu: 1
             memory: 2Gi
+      volumes:
+      - name: kafka-data
+        persistentVolumeClaim:
+          claimName: kafka1-pvc
 ---
 apiVersion: v1
 kind: Service
@@ -148,6 +164,15 @@ spec:
                   operator: In
                   values: ["kafka1", "kafka2", "kafka3"]
               topologyKey: kubernetes.io/hostname
+      initContainers:
+      - name: fix-permissions
+        image: busybox
+        command: ['sh', '-c', 'rm -rf /var/lib/kafka/data/lost+found && chown -R 1000:1000 /var/lib/kafka/data']
+        volumeMounts:
+        - name: kafka-data
+          mountPath: /var/lib/kafka/data
+        securityContext:
+          runAsUser: 0
       containers:
       - name: kafka2
         image: confluentinc/cp-kafka:7.6.0
@@ -164,6 +189,9 @@ spec:
           value: "INTERNAL://kafka2:29093,EXTERNAL://kafka2:9093"
         - name: KAFKA_LISTENERS
           value: "INTERNAL://0.0.0.0:29093,EXTERNAL://0.0.0.0:9093"
+        volumeMounts:
+        - name: kafka-data
+          mountPath: /var/lib/kafka/data
         resources:
           requests:
             cpu: 500m
@@ -171,6 +199,10 @@ spec:
           limits:
             cpu: 1
             memory: 2Gi
+      volumes:
+      - name: kafka-data
+        persistentVolumeClaim:
+          claimName: kafka2-pvc
 ---
 apiVersion: v1
 kind: Service
@@ -214,6 +246,15 @@ spec:
                   operator: In
                   values: ["kafka1", "kafka2", "kafka3"]
               topologyKey: kubernetes.io/hostname
+      initContainers:
+      - name: fix-permissions
+        image: busybox
+        command: ['sh', '-c', 'rm -rf /var/lib/kafka/data/lost+found && chown -R 1000:1000 /var/lib/kafka/data']
+        volumeMounts:
+        - name: kafka-data
+          mountPath: /var/lib/kafka/data
+        securityContext:
+          runAsUser: 0
       containers:
       - name: kafka3
         image: confluentinc/cp-kafka:7.6.0
@@ -230,6 +271,9 @@ spec:
           value: "INTERNAL://kafka3:29094,EXTERNAL://kafka3:9094"
         - name: KAFKA_LISTENERS
           value: "INTERNAL://0.0.0.0:29094,EXTERNAL://0.0.0.0:9094"
+        volumeMounts:
+        - name: kafka-data
+          mountPath: /var/lib/kafka/data
         resources:
           requests:
             cpu: 500m
@@ -237,6 +281,10 @@ spec:
           limits:
             cpu: 1
             memory: 2Gi
+      volumes:
+      - name: kafka-data
+        persistentVolumeClaim:
+          claimName: kafka3-pvc
 ---
 apiVersion: v1
 kind: Service

--- a/k8s/kafka/kafka-deployment.yaml
+++ b/k8s/kafka/kafka-deployment.yaml
@@ -1,0 +1,255 @@
+# kafka-configmap.yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kafka-config
+  namespace: hertz-tuning-dev
+data:
+  ZOOKEEPER_CLIENT_PORT: "2181"
+  ZOOKEEPER_TICK_TIME: "2000"
+  KAFKA_ZOOKEEPER_CONNECT: "zookeeper:2181"
+  KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: "INTERNAL:PLAINTEXT,EXTERNAL:PLAINTEXT"
+  KAFKA_INTER_BROKER_LISTENER_NAME: "INTERNAL"
+  KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: "3"
+---
+# kafka-cluster.yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: zookeeper
+  namespace: hertz-tuning-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: zookeeper
+  template:
+    metadata:
+      labels:
+        app: zookeeper
+    spec:
+      containers:
+      - name: zookeeper
+        image: confluentinc/cp-zookeeper:7.6.0
+        ports:
+        - containerPort: 2181
+        envFrom:
+        - configMapRef:
+            name: kafka-config
+        resources:
+          requests:
+            cpu: 200m
+            memory: 512Mi
+          limits:
+            cpu: 500m
+            memory: 1Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: zookeeper
+  namespace: hertz-tuning-dev
+spec:
+  selector:
+    app: zookeeper
+  ports:
+  - port: 2181
+    targetPort: 2181
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka1
+  namespace: hertz-tuning-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka1
+  template:
+    metadata:
+      labels:
+        app: kafka1
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values: ["kafka1", "kafka2", "kafka3"]
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: kafka1
+        image: confluentinc/cp-kafka:7.6.0
+        ports:
+        - containerPort: 9092
+        - containerPort: 29092
+        envFrom:
+        - configMapRef:
+            name: kafka-config
+        env:
+        - name: KAFKA_BROKER_ID
+          value: "1"
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: "INTERNAL://kafka1:29092,EXTERNAL://kafka1:9092"
+        - name: KAFKA_LISTENERS
+          value: "INTERNAL://0.0.0.0:29092,EXTERNAL://0.0.0.0:9092"
+        resources:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: 1
+            memory: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka1
+  namespace: hertz-tuning-dev
+spec:
+  selector:
+    app: kafka1
+  ports:
+  - name: external
+    port: 9092
+    targetPort: 9092
+  - name: internal
+    port: 29092
+    targetPort: 29092
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka2
+  namespace: hertz-tuning-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka2
+  template:
+    metadata:
+      labels:
+        app: kafka2
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values: ["kafka1", "kafka2", "kafka3"]
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: kafka2
+        image: confluentinc/cp-kafka:7.6.0
+        ports:
+        - containerPort: 9093
+        - containerPort: 29093
+        envFrom:
+        - configMapRef:
+            name: kafka-config
+        env:
+        - name: KAFKA_BROKER_ID
+          value: "2"
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: "INTERNAL://kafka2:29093,EXTERNAL://kafka2:9093"
+        - name: KAFKA_LISTENERS
+          value: "INTERNAL://0.0.0.0:29093,EXTERNAL://0.0.0.0:9093"
+        resources:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: 1
+            memory: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka2
+  namespace: hertz-tuning-dev
+spec:
+  selector:
+    app: kafka2
+  ports:
+  - name: external
+    port: 9093
+    targetPort: 9093
+  - name: internal
+    port: 29093
+    targetPort: 29093
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kafka3
+  namespace: hertz-tuning-dev
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: kafka3
+  template:
+    metadata:
+      labels:
+        app: kafka3
+    spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values: ["kafka1", "kafka2", "kafka3"]
+              topologyKey: kubernetes.io/hostname
+      containers:
+      - name: kafka3
+        image: confluentinc/cp-kafka:7.6.0
+        ports:
+        - containerPort: 9094
+        - containerPort: 29094
+        envFrom:
+        - configMapRef:
+            name: kafka-config
+        env:
+        - name: KAFKA_BROKER_ID
+          value: "3"
+        - name: KAFKA_ADVERTISED_LISTENERS
+          value: "INTERNAL://kafka3:29094,EXTERNAL://kafka3:9094"
+        - name: KAFKA_LISTENERS
+          value: "INTERNAL://0.0.0.0:29094,EXTERNAL://0.0.0.0:9094"
+        resources:
+          requests:
+            cpu: 500m
+            memory: 1Gi
+          limits:
+            cpu: 1
+            memory: 2Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kafka3
+  namespace: hertz-tuning-dev
+spec:
+  selector:
+    app: kafka3
+  ports:
+  - name: external
+    port: 9094
+    targetPort: 9094
+  - name: internal
+    port: 29094
+    targetPort: 29094

--- a/k8s/kafka/kafka-pvc.yaml
+++ b/k8s/kafka/kafka-pvc.yaml
@@ -1,0 +1,39 @@
+# kafka-pvc.yaml
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kafka1-pvc
+  namespace: hertz-tuning-dev
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: mysql-ebs
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kafka2-pvc
+  namespace: hertz-tuning-dev
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: mysql-ebs
+  resources:
+    requests:
+      storage: 10Gi
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: kafka3-pvc
+  namespace: hertz-tuning-dev
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: mysql-ebs
+  resources:
+    requests:
+      storage: 10Gi


### PR DESCRIPTION
## 🔗 관련 이슈
- (https://github.com/100-hours-a-week/2-hertz-wiki/issues/405)
## ✏️ 변경 사항
- k8s kafka 추가
- pvc 설정

## 📋 상세 설명
✅ Kafka PVC는 기술적으로는 필수가 아니지만, 실무적으로는 운영환경에서 필수
✅ 실시간 서비스에서도 장애 복구, 유실 방지, 서비스 신뢰성 확보를 원한다면 PVC 없이 운영하는 것은 권장되지 않음

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.