### PR TITLE
feat: FCM secret_key 볼륨 마운트

### DIFF
--- a/k8s-argocd-helm/apps/backend/templates/deployment.yaml
+++ b/k8s-argocd-helm/apps/backend/templates/deployment.yaml
@@ -66,16 +66,16 @@ spec:
               value: "%d{yyyy-MM-dd HH:mm:ss} [%thread] %-5level %logger{36} - %msg%n"
             - name: JAVA_TOOL_OPTIONS
               value: "-javaagent:/otel/opentelemetry-javaagent.jar"
+
             - name: KAFKA_SSE_GROUP_ID
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.name
-          volumeMounts:
-            - name: otel-agent
-              mountPath: /otel
+
           ports:
             - containerPort: {{ .Values.app.ports.http }}
             - containerPort: {{ .Values.app.ports.websocket }}
+
           readinessProbe:
             httpGet:
               path: /api/ping
@@ -85,6 +85,7 @@ spec:
             timeoutSeconds: {{ .Values.healthCheck.readiness.timeoutSeconds }}
             failureThreshold: {{ .Values.healthCheck.readiness.failureThreshold }}
             successThreshold: {{ .Values.healthCheck.readiness.successThreshold }}
+
           livenessProbe:
             httpGet:
               path: /api/ping
@@ -93,6 +94,7 @@ spec:
             periodSeconds: {{ .Values.healthCheck.liveness.periodSeconds }}
             timeoutSeconds: {{ .Values.healthCheck.liveness.timeoutSeconds }}
             failureThreshold: {{ .Values.healthCheck.liveness.failureThreshold }}
+
           resources:
             requests:
               cpu: {{ .Values.resources.requests.cpu }}
@@ -101,6 +103,20 @@ spec:
               cpu: {{ .Values.resources.limits.cpu }}
               memory: {{ .Values.resources.limits.memory }}
 
+          volumeMounts:
+            - name: otel-agent
+              mountPath: /otel
+            # 오직 TUNING_FCM 키만 이 경로에 파일로 제공
+            - name: fcm-cert-volume
+              mountPath: /app
+              readOnly: true
+
       volumes:
         - name: otel-agent
           emptyDir: {}
+        - name: fcm-cert-volume
+          secret:
+            secretName: springboot-secrets
+            items:
+              - key: TUNING_FCM
+                path: tuning-fcm-certification.json

--- a/k8s-argocd-helm/apps/monitoring/templates/loki.yaml
+++ b/k8s-argocd-helm/apps/monitoring/templates/loki.yaml
@@ -2,7 +2,7 @@ apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
   name: loki
-  namespace: argocd
+  namespace: {{ .Values.global.namespace }}
   annotations:
     argocd.argoproj.io/sync-wave: "3"
 spec:


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- FCM 도입으로 fcm.certification json 파일을  마운트 하는 로직 deployment에 추가

## 📋 상세 설명
```
          volumeMounts:
            - name: otel-agent
              mountPath: /otel
            # 오직 TUNING_FCM 키만 이 경로에 파일로 제공
            - name: fcm-cert-volume
              mountPath: /app
              readOnly: true
```
```
      volumes:
        - name: otel-agent
          emptyDir: {}
        - name: fcm-cert-volume
          secret:
            secretName: springboot-secrets
            items:
              - key: TUNING_FCM
                path: tuning-fcm-certification.json
```

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.