### PR TITLE
fix: fcm.certification 이라는 환경변수를 못 읽어오는 문제 해결

### DIFF
--- a/k8s-argocd-helm/apps/backend/templates/deployment.yaml
+++ b/k8s-argocd-helm/apps/backend/templates/deployment.yaml
@@ -67,6 +67,10 @@ spec:
             - name: JAVA_TOOL_OPTIONS
               value: "-javaagent:/otel/opentelemetry-javaagent.jar"
 
+            # fcm.certification 속성에 마운트된 파일의 절대 경로를 지정합니다.
+            - name: FCM_CERTIFICATION
+              value: "/app/tuning-fcm-certification.json"
+
             - name: KAFKA_SSE_GROUP_ID
               valueFrom:
                 fieldRef:
@@ -106,9 +110,10 @@ spec:
           volumeMounts:
             - name: otel-agent
               mountPath: /otel
-            # 오직 TUNING_FCM 키만 이 경로에 파일로 제공
+            # subPath를 사용하여 디렉터리를 덮어쓰지 않고 파일만 마운트합니다.
             - name: fcm-cert-volume
-              mountPath: /app
+              mountPath: /app/tuning-fcm-certification.json
+              subPath: tuning-fcm-certification.json
               readOnly: true
 
       volumes:


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
      # fcm.certification 속성에 마운트된 파일의 절대 경로를 지정합니다.
```
            - name: FCM_CERTIFICATION
              value: "/app/tuning-fcm-certification.json"
```

## 📋 상세 설명
- 작업한 이유와 구체적인 변경 내용을 작성해 주세요.
- 필요한 경우 주요 흐름이나 로직 변경사항을 함께 설명해 주세요.

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.