### PR TITLE
fix: fcm resources mount 포인트를 변경

### DIFF
--- a/k8s-argocd-helm/apps/backend/templates/deployment.yaml
+++ b/k8s-argocd-helm/apps/backend/templates/deployment.yaml
@@ -68,7 +68,7 @@ spec:
               value: "-javaagent:/otel/opentelemetry-javaagent.jar"
             # fcm.certification 속성에 마운트된 파일의 절대 경로를 지정합니다.
             - name: FCM_CERTIFICATION
-              value: "/app/tuning-fcm-certification.json"
+              value: "tuning-fcm-certification.json"
             - name: KAFKA_SSE_GROUP_ID
               valueFrom:
                 fieldRef:
@@ -77,9 +77,12 @@ spec:
             - name: otel-agent
               mountPath: /otel
             # subPath를 사용하여 디렉터리를 덮어쓰지 않고 파일만 마운트합니다.
+            # - name: fcm-cert-volume
+            #   mountPath: /app/tuning-fcm-certification.json
+            #   subPath: tuning-fcm-certification.json
+            #   readOnly: true
             - name: fcm-cert-volume
-              mountPath: /app/tuning-fcm-certification.json
-              subPath: tuning-fcm-certification.json
+              mountPath: /app/resources
               readOnly: true
           ports:
             - containerPort: {{ .Values.app.ports.http }}
@@ -115,9 +118,12 @@ spec:
       volumes:
         - name: otel-agent
           emptyDir: {}
+        # - name: fcm-cert-volume
+        #   secret:
+        #     secretName: springboot-fcm-secret
+        #     items:
+        #       - key: tuning-fcm-certification.json
+        #         path: tuning-fcm-certification.json
         - name: fcm-cert-volume
           secret:
             secretName: springboot-fcm-secret
-            items:
-              - key: tuning-fcm-certification.json
-                path: tuning-fcm-certification.json


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- resources 라닌 디렉토리 자체를 볼륨설정하여 mount
```
- name: fcm-cert-volume
              mountPath: /app/resources
              readOnly: true
```
```
- name: fcm-cert-volume
          secret:
            secretName: springboot-fcm-secret
```

## 📋 상세 설명
- 작업한 이유와 구체적인 변경 내용을 작성해 주세요.
- 필요한 경우 주요 흐름이나 로직 변경사항을 함께 설명해 주세요.

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.