### PR TITLE
fix: ALB ingress 중 backend 헬스체크가 안되는 문제 해결

### DIFF
--- a/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
+++ b/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
@@ -12,6 +12,8 @@ metadata:
     alb.ingress.kubernetes.io/healthcheck-interval-seconds: "10"
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS":443}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
+    alb.ingress.kubernetes.io/healthcheck-path: /api/ping
+    alb.ingress.kubernetes.io/success-codes: "200"
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   rules:


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- ALB ingress 중 backend 헬스체크가 안되는 문제 해결

## 📋 상세 설명
- 헬스체크 url을 /api/ping으로 지정

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.