### PR TITLE
fix: 로드밸런서 target group의 헬스체크 오류 및 timeout 설정 누락 해결

### DIFF
--- a/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
+++ b/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
@@ -93,7 +93,7 @@ metadata:
     alb.ingress.kubernetes.io/backend-protocol: HTTP
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS":443}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
-    alb.ingress.kubernetes.io/healthcheck-path: /socket.io/health
+    alb.ingress.kubernetes.io/healthcheck-path: /socket.io
     alb.ingress.kubernetes.io/success-codes: "200"
 spec:
   ingressClassName: {{ .Values.ingress.className }}

--- a/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
+++ b/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
@@ -51,6 +51,7 @@ metadata:
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
     alb.ingress.kubernetes.io/healthcheck-path: /api/ping
     alb.ingress.kubernetes.io/success-codes: "200"
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=86400
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   rules:
@@ -95,6 +96,7 @@ metadata:
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
     alb.ingress.kubernetes.io/healthcheck-path: /socket.io
     alb.ingress.kubernetes.io/success-codes: "200"
+    alb.ingress.kubernetes.io/load-balancer-attributes: idle_timeout.timeout_seconds=86400
 spec:
   ingressClassName: {{ .Values.ingress.className }}
   rules:

--- a/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
+++ b/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
-    alb.ingress.kubernetes.io/group.name: tuning-alb-group-frontend
+    alb.ingress.kubernetes.io/group.name: tuning-alb-group
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/backend-protocol: HTTP
@@ -43,7 +43,7 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
-    alb.ingress.kubernetes.io/group.name: tuning-alb-group-backend
+    alb.ingress.kubernetes.io/group.name: tuning-alb-group
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/backend-protocol: HTTP
@@ -87,7 +87,7 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
-    alb.ingress.kubernetes.io/group.name: tuning-alb-group-websocket
+    alb.ingress.kubernetes.io/group.name: tuning-alb-group
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/backend-protocol: HTTP

--- a/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
+++ b/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
@@ -1,18 +1,18 @@
+# Frontend Ingress
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: tuning-alb-ingress
+  name: tuning-alb-ingress-frontend
   namespace: {{ .Values.global.namespace }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
+    alb.ingress.kubernetes.io/group.name: tuning-alb-group
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/backend-protocol: HTTP
-    alb.ingress.kubernetes.io/healthcheck-timeout-seconds: "5"
-    alb.ingress.kubernetes.io/healthcheck-interval-seconds: "10"
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS":443}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
-    alb.ingress.kubernetes.io/healthcheck-path: /api/ping
+    alb.ingress.kubernetes.io/healthcheck-path: /
     alb.ingress.kubernetes.io/success-codes: "200"
 spec:
   ingressClassName: {{ .Values.ingress.className }}
@@ -26,6 +26,36 @@ spec:
                 name: {{ .Values.services.frontend }}
                 port:
                   number: 80
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ .Values.services.frontend }}
+                port:
+                  number: 80
+
+---
+# Backend Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tuning-alb-ingress-backend
+  namespace: {{ .Values.global.namespace }}
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
+    alb.ingress.kubernetes.io/group.name: tuning-alb-group
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS":443}]'
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
+    alb.ingress.kubernetes.io/healthcheck-path: /api/ping
+    alb.ingress.kubernetes.io/success-codes: "200"
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - http:
+        paths:
           - path: /api
             pathType: Prefix
             backend:
@@ -33,7 +63,6 @@ spec:
                 name: {{ .Values.services.backend }}
                 port:
                   number: 80
-
           - path: /swagger-ui/
             pathType: Prefix
             backend:
@@ -48,6 +77,29 @@ spec:
                 name: {{ .Values.services.backend }}
                 port:
                   number: 80
+
+---
+# WebSocket Ingress
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tuning-alb-ingress-websocket
+  namespace: {{ .Values.global.namespace }}
+  annotations:
+    kubernetes.io/ingress.class: {{ .Values.ingress.className }}
+    alb.ingress.kubernetes.io/group.name: tuning-alb-group
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: ip
+    alb.ingress.kubernetes.io/backend-protocol: HTTP
+    alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS":443}]'
+    alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
+    alb.ingress.kubernetes.io/healthcheck-path: /socket.io/health
+    alb.ingress.kubernetes.io/success-codes: "200"
+spec:
+  ingressClassName: {{ .Values.ingress.className }}
+  rules:
+    - http:
+        paths:
           - path: /socket.io
             pathType: Prefix
             backend:
@@ -55,10 +107,3 @@ spec:
                 name: {{ .Values.services.backend }}
                 port:
                   number: {{ .Values.services.websocketPort }}
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ .Values.services.frontend }}
-                port:
-                  number: 80

--- a/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
+++ b/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
-    alb.ingress.kubernetes.io/group.name: tuning-alb-group
+    alb.ingress.kubernetes.io/group.name: tuning-alb-group-frontend
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/backend-protocol: HTTP
@@ -43,7 +43,7 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
-    alb.ingress.kubernetes.io/group.name: tuning-alb-group
+    alb.ingress.kubernetes.io/group.name: tuning-alb-group-backend
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/backend-protocol: HTTP
@@ -87,7 +87,7 @@ metadata:
   namespace: {{ .Values.global.namespace }}
   annotations:
     kubernetes.io/ingress.class: {{ .Values.ingress.className }}
-    alb.ingress.kubernetes.io/group.name: tuning-alb-group
+    alb.ingress.kubernetes.io/group.name: tuning-alb-group-websocket
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
     alb.ingress.kubernetes.io/backend-protocol: HTTP


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- 로드밸런서 target group의 헬스체크 오류 및 timeout 설정 누락 해결

## 📋 상세 설명
- 로드밸런서 target group의 헬스체크 오류 및 timeout 설정 누락 해결

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.