### PR TITLE
refactor: Provisoner에서 스팟 인스턴스를 제외, Provisoner 종류를 1개로 줄임

### DIFF
--- a/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
+++ b/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
@@ -49,7 +49,7 @@ metadata:
     alb.ingress.kubernetes.io/backend-protocol: HTTP
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS":443}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
-    alb.ingress.kubernetes.io/healthcheck-path: /api/ping
+    alb.ingress.kubernetes.io/healthcheck-path: /socket.io/ping
     alb.ingress.kubernetes.io/success-codes: "200"
 spec:
   ingressClassName: {{ .Values.ingress.className }}

--- a/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
+++ b/k8s-argocd-helm/infrastructure/alb/templates/ingress.yaml
@@ -49,7 +49,7 @@ metadata:
     alb.ingress.kubernetes.io/backend-protocol: HTTP
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP":80,"HTTPS":443}]'
     alb.ingress.kubernetes.io/certificate-arn: {{ .Values.ingress.certificateArn }}
-    alb.ingress.kubernetes.io/healthcheck-path: /socket.io/ping
+    alb.ingress.kubernetes.io/healthcheck-path: /api/ping
     alb.ingress.kubernetes.io/success-codes: "200"
 spec:
   ingressClassName: {{ .Values.ingress.className }}

--- a/k8s-argocd-helm/infrastructure/karpenter/provisioner-general.yaml
+++ b/k8s-argocd-helm/infrastructure/karpenter/provisioner-general.yaml
@@ -6,10 +6,10 @@ spec:
   requirements:
     - key: node.kubernetes.io/instance-type
       operator: In
-      values: ["t3.medium", "t3.small", "t3.micro"] # 일반 애플리케이션 용도
+      values: ["t3.xlarge", "t3.large", "t3.medium", "t3.small", "t3.micro"] # 일반 애플리케이션 용도
     - key: karpenter.sh/capacity-type
       operator: In
-      values: ["spot", "on-demand"] # On-Demand 인스턴스 사용
+      values: ["on-demand"] # On-Demand 인스턴스 사용
   providerRef:
     name: default
   limits:
@@ -17,27 +17,5 @@ spec:
       cpu: "8" # 총 8 vCPU 이상 노드 생성하지 않도록 제한 (선택적)
   labels:
     workload-type: "general"
-  consolidation:
-    enabled: true
----
-apiVersion: karpenter.sh/v1alpha5
-kind: Provisioner
-metadata:
-  name: memory-optimized-workload
-spec:
-  requirements:
-    - key: node.kubernetes.io/instance-type
-      operator: In
-      values: ["t3.large", "t3.xlarge", "m5.large"] # 메모리 최적화 애플리케이션 용도
-    - key: karpenter.sh/capacity-type
-      operator: In
-      values: ["spot", "on-demand"] # On-Demand 인스턴스 사용
-  providerRef:
-    name: default
-  limits:
-    resources:
-      cpu: "8" # 총 8 vCPU 이상 노드 생성하지 않도록 제한 (선택적)
-  labels:
-    workload-type: "memory-optimized"
   consolidation:
     enabled: true


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- Provisoner에서 스팟 인스턴스를 제외, Provisoner 종류를 1개로 줄임

## 📋 상세 설명
- Provisoner에서 스팟 인스턴스를 제외, Provisoner 종류를 1개로 줄임

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.