### PR TITLE
refactor: 클러스터 기본 워크노드의 감소로 인한 프로비저닝 가능한 CPU 부족 해결

### DIFF
--- a/k8s-argocd-helm/infrastructure/karpenter/provisioner-general.yaml
+++ b/k8s-argocd-helm/infrastructure/karpenter/provisioner-general.yaml
@@ -14,7 +14,7 @@ spec:
     name: default
   limits:
     resources:
-      cpu: "8" # 총 8 vCPU 이상 노드 생성하지 않도록 제한 (선택적)
+      cpu: "16" # 총 8 vCPU 이상 노드 생성하지 않도록 제한 (선택적)
   labels:
     workload-type: "general"
   consolidation:


### PR DESCRIPTION
## 🔗 관련 이슈
- 이 PR이 연결된 이슈 번호를 작성해 주세요. (예: `#123`)

## ✏️ 변경 사항
- 클러스터 기본 워크노드의 감소로 인한 프로비저닝 가능한 CPU 부족 해결

## 📋 상세 설명
- CPU 제한 조정: `8` -> `16`

## ✅ 체크리스트
- [ ] 기능이 정상적으로 동작하는지 확인했습니다.
- [ ] 기존 기능에 영향을 주지 않는지 확인했습니다.
- [ ] 문서 또는 관련 설정을 수정했습니다. (필요 시)

## 👀 리뷰 요청 사항
- 중점적으로 확인이 필요한 부분이 있다면 작성해 주세요.

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.